### PR TITLE
simplified debugging start

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,10 +9,7 @@
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "npm",
-      "runtimeArgs": [
-        "run-script",
-        "start-desktop"
-      ],
+      "runtimeArgs": ["run-script", "start", "desktop"]
     },
     {
       "name": "Office Online (Edge)",
@@ -28,10 +25,9 @@
   ],
   "inputs": [
     {
-        "id": "officeOnlineDocumentUrl",
-        "type": "promptString",
-        "description": "Please enter the url for the Office Online document.",
+      "id": "officeOnlineDocumentUrl",
+      "type": "promptString",
+      "description": "Please enter the url for the Office Online document."
     }
-],
-
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,96 +1,85 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "Build (Development)",
-            "type": "npm",
-            "script": "build-dev",
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "presentation": {
-                "clear": true,
-                "panel": "shared",
-                "showReuseMessage": false
-            }
-        },
-        {
-            "label": "Build (Production)",
-            "type": "npm",
-            "script": "build",
-            "group":  "build",
-            "presentation": {
-                "clear": true,
-                "panel": "shared",
-                "showReuseMessage": false
-            }
-        },
-        {
-            "label": "Debug: Desktop",
-            "type": "npm",
-            "script": "start-desktop",
-            "presentation": {
-                "clear": true,
-                "panel": "shared",
-                "showReuseMessage": false
-            },
-            "problemMatcher": []
-        },
-        {
-            "label": "Debug: Web",
-            "type": "npm",
-            "script": "start-web",
-            "presentation": {
-                "clear": true,
-                "panel": "shared",
-                "showReuseMessage": false
-            },
-            "problemMatcher": []
-        },
-        {
-            "label": "Dev Server",
-            "type": "npm",
-            "script": "dev-server",
-            "presentation": {
-                "clear": true,
-                "panel": "dedicated",
-            },
-            "problemMatcher": []
-        },
-        {
-            "label": "Install",
-            "type": "npm",
-            "script": "install",
-            "presentation": {
-                "clear": true,
-                "panel": "shared",
-                "showReuseMessage": false
-            },
-            "problemMatcher": []
-        },
-        {
-            "label": "Stop Debug",
-            "type": "npm",
-            "script": "stop",
-            "presentation": {
-                "clear": true,
-                "panel": "shared",
-                "showReuseMessage": false
-            },
-            "problemMatcher": []
-        },
-        {
-            "label": "Watch",
-            "type": "npm",
-            "script": "watch",
-            "presentation": {
-                "clear": true,
-                "panel": "dedicated",
-            },
-            "problemMatcher": []
-        }
-    ]
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build (Development)",
+      "type": "npm",
+      "script": "build-dev",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "clear": true,
+        "panel": "shared",
+        "showReuseMessage": false
+      }
+    },
+    {
+      "label": "Build (Production)",
+      "type": "npm",
+      "script": "build",
+      "group": "build",
+      "presentation": {
+        "clear": true,
+        "panel": "shared",
+        "showReuseMessage": false
+      }
+    },
+    {
+      "label": "Debug: Web",
+      "type": "npm",
+      "script": "start:web",
+      "presentation": {
+        "clear": true,
+        "panel": "shared",
+        "showReuseMessage": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Dev Server",
+      "type": "npm",
+      "script": "dev-server",
+      "presentation": {
+        "clear": true,
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Install",
+      "type": "npm",
+      "script": "install",
+      "presentation": {
+        "clear": true,
+        "panel": "shared",
+        "showReuseMessage": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Stop Debug",
+      "type": "npm",
+      "script": "stop",
+      "presentation": {
+        "clear": true,
+        "panel": "shared",
+        "showReuseMessage": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Watch",
+      "type": "npm",
+      "script": "watch",
+      "presentation": {
+        "clear": true,
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4243,17 +4243,17 @@
       "dev": true
     },
     "office-addin-debugging": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/office-addin-debugging/-/office-addin-debugging-1.4.1.tgz",
-      "integrity": "sha512-h8mjPgRllEaa5LmufsAnYWMNEJOn+pXseBFpLiSyTXzKyry2Q3exdiDsOVv3iHJckP6VyHFbwiahUdZf8OwHQg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/office-addin-debugging/-/office-addin-debugging-2.0.0.tgz",
+      "integrity": "sha512-zjuTSa5H63LnLe67OOqnHW2wXQe1oV6kyn55zxJgEAZ9GK7Lgo7oQu5oX+BME76W8gsr7JN1umu3JjGlRuy07g==",
       "dev": true,
       "requires": {
         "child_process": "^1.0.2",
         "commander": "^2.19.0",
         "node-fetch": "^2.2.0",
-        "office-addin-dev-settings": "^1.3.0",
-        "office-addin-manifest": "^1.2.0",
-        "office-addin-node-debugger": "^0.2.0"
+        "office-addin-dev-settings": "^1.4.0",
+        "office-addin-manifest": "^1.2.1",
+        "office-addin-node-debugger": "^0.3.2"
       },
       "dependencies": {
         "commander": {
@@ -4265,15 +4265,15 @@
       }
     },
     "office-addin-dev-settings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/office-addin-dev-settings/-/office-addin-dev-settings-1.3.0.tgz",
-      "integrity": "sha512-bby8ZQI59NW22zVCT3rMVI3lsu14sDP4bt5vsuCCcUyy5lgi32v2egDDRD6NVd/juc0mecZ0EmpgRg0tYHONYA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/office-addin-dev-settings/-/office-addin-dev-settings-1.4.0.tgz",
+      "integrity": "sha512-EBanKbB/c7VhhMn4wzkeDaUUZwtJFRz893zNWoz3OFSVN0biPxkbXNTZMI9OlXQpYYFHcI6zjhCNFnDRQtvuQQ==",
       "dev": true,
       "requires": {
         "child_process": "^1.0.2",
         "commander": "^2.18.0",
         "fs": "0.0.1-security",
-        "office-addin-manifest": "^1.2.0",
+        "office-addin-manifest": "^1.2.1",
         "whatwg-url": "^7.0.0",
         "winreg": "^1.2.4"
       },
@@ -4287,9 +4287,9 @@
       }
     },
     "office-addin-manifest": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.2.0.tgz",
-      "integrity": "sha512-LjQLLas7FrQBs7X9E20hvokQHfRSA9upJnZ/VSE2JZm1Mp8DENRG6CslwKj1M1n792wWrjpiL+feyX1q2W3KFw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-1.2.1.tgz",
+      "integrity": "sha512-vDl4ls/hkNsFuIuesQsFmXI6QQYgNhmgNRlIHUIAKmHYmPo8ciSonnGBNIOCj7QUKU7d0VPhqtAA4tw3Er6ATQ==",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
@@ -4309,15 +4309,23 @@
       }
     },
     "office-addin-node-debugger": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/office-addin-node-debugger/-/office-addin-node-debugger-0.2.0.tgz",
-      "integrity": "sha512-UmXAdhFzZ8yWSTEAtDQrouQR7ZJg0tRExKsJqw25edl1jH46MmWgFSZk+FkwL4YmG5mA7X6RHeER3meDWjrOyA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/office-addin-node-debugger/-/office-addin-node-debugger-0.3.2.tgz",
+      "integrity": "sha512-UeC3iXjQi1BQWxi3DjMfcSVbbq69tPa7kY2EzDhcgltdxLJPAxBOUYehzwnEmtCM8Y0bp00scw9B/7BL30DEhQ==",
       "dev": true,
       "requires": {
         "child_process": "^1.0.2",
-        "commander": "^2.9.0",
+        "commander": "^2.19.0",
         "node-fetch": "^2.2.0",
-        "ws": "^6.0.0"
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "dev": true
+        }
       }
     },
     "office-addin-validator": {
@@ -6879,9 +6887,9 @@
       "dev": true
     },
     "ws": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
-      "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
+      "integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"

--- a/package.json
+++ b/package.json
@@ -6,15 +6,19 @@
     "url": "https://github.com/OfficeDev/Office-Addin-TaskPane.git"
   },
   "license": "MIT",
+  "config": {
+    "app-type-to-debug": "desktop",
+    "dev-server-port": 3000
+  },
   "scripts": {
     "build": "webpack -p --mode production",
     "build-dev": "webpack --mode development",
     "dev-server": "webpack-dev-server --mode development",
     "sideload": "office-toolbox sideload -m manifest.xml -a excel",
-    "start": "npm run start-desktop",
-    "start-desktop": "office-addin-debugging start manifest.xml --dev-server \"npm run dev-server\" --dev-server-port 3000 --sideload \"npm run sideload\" --no-live-reload",
-    "start-web": "office-addin-debugging start manifest.xml --dev-server \"npm run dev-server\" --dev-server-port 3000 --no-debug --no-live-reload",
-    "stop": "office-addin-debugging stop manifest.xml --unload \"npm run unload\"",
+    "start": "office-addin-debugging start manifest.xml",
+    "start:desktop": "office-addin-debugging start manifest.xml desktop",
+    "start:web": "office-addin-debugging start manifest.xml web",
+    "stop": "office-addin-debugging stop manifest.xml",
     "unload": "office-toolbox remove -m manifest.xml -a excel",
     "validate": "office-toolbox validate -m manifest.xml",
     "watch": "webpack --mode development --watch"
@@ -38,8 +42,8 @@
     "fs": "0.0.1-security",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
-    "office-addin-debugging": "^1.4.0",
-    "office-toolbox": "^0.1.0",
+    "office-addin-debugging": "^2.0.0",
+    "office-toolbox": "^0.1.1",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^5.3.1",
     "typescript": "^3.1.6",


### PR DESCRIPTION
Updated office-addin-debugging package to v2.0.0 which supports reading package.json config for values rather than requiring command line options to be set. Allows the appType to be set so that the debugging start command can do the appropriate thing for each type of app.