### PR TITLE
fix vscode launch config for npm args

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,21 +9,24 @@
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "start", "desktop", "--", "--app", "excel"]
+      "runtimeArgs": ["run", "start", "desktop"],
+      "args": ["--", "--app", "excel"]
     },
     {
       "name": "PowerPoint Desktop",
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "start", "desktop", "--", "--app", "powerpoint"]
+      "runtimeArgs": ["run", "start", "desktop"],
+      "args": ["--", "--app", "powerpoint"]
     },
     {
       "name": "Word Desktop",
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "start", "desktop", "--", "--app", "word"]
+      "runtimeArgs": ["run", "start", "desktop"],
+      "args": ["--", "--app", "word"]
     },
     {
       "name": "Office Online (Chrome)",


### PR DESCRIPTION
Based on https://github.com/Microsoft/vscode/issues/68443, the VSCode launch config needs to be updated to pass arguments to npm correctly.
