### PR TITLE
Run 'Dev Server' task when VSCode is opened

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,7 +47,10 @@
         "clear": true,
         "panel": "dedicated"
       },
-      "problemMatcher": []
+      "problemMatcher": [],
+      "runOptions": {
+        "runOn": "folderOpen"
+      }
     },
     {
       "label": "Install",


### PR DESCRIPTION
This change to .vscode\tasks.json allows the Dev Server task to automatically run when the folder is opened in VS Code if "Allow Automatic Tasks in Folder" is enabled for the folder.