### PR TITLE
enhance webpack config for https and port

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,9 +62,9 @@ module.exports = async (env, options) => {
     devServer: {
       headers: {
         "Access-Control-Allow-Origin": "*"
-      },
-      https: await devCerts.getHttpsServerOptions(),
-      port: 3000
+      },      
+      https: (options.https !== undefined) ? options.https : await devCerts.getHttpsServerOptions(),
+      port: process.env.npm_package_config_dev_server_port || 3000
     }
   };
 


### PR DESCRIPTION
* if '--https false' is specified when calling webpack or webpack-dev-server,
  it will use http instead of https.

  This will run the dev server using http:
  `npm run dev-server -- --https false`

  This will build without prompting for dev certs:
  `npm run build -- --https false`

* Get the port from the package.json config "dev-server-port".

  If the value of this config is changed in package.json, "npm run dev-server" will use it.