### PR TITLE
Bug 3426728: Use correct copyright header in templates

### DIFF
--- a/src/commands/commands.html
+++ b/src/commands/commands.html
@@ -1,4 +1,4 @@
-<!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See full license in root of repo. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. -->
 
 <!DOCTYPE html>
 <html>

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -1,4 +1,4 @@
-<!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See full license in root of repo. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. -->
 <!-- This file shows how to design a first-run page that provides a welcome screen to the user about the features of the add-in. -->
 
 <!DOCTYPE html>

--- a/test/src/test-taskpane.html
+++ b/test/src/test-taskpane.html
@@ -1,4 +1,4 @@
-<!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See full license in root of repo. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. -->
 <!-- This file shows how to design a first-run page that provides a welcome screen to the user about the features of the add-in. -->
 
 <!DOCTYPE html>


### PR DESCRIPTION
- Fix copyright headers in project html files
- Note, I checked the headers in the other project files (.ts and .css) and they are currently fine