### PR TITLE
office-toolbox@0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6319,9 +6319,9 @@
       }
     },
     "office-toolbox": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/office-toolbox/-/office-toolbox-0.2.1.tgz",
-      "integrity": "sha512-faU44VZyGLzi6QljttQDLtOwt7vZ0jICYJlFo1hZjFAeC+UFpgyr38VodKEqdKhZ2eeUqwPER+O340c1dMjE7Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/office-toolbox/-/office-toolbox-0.3.0.tgz",
+      "integrity": "sha512-RQL8k1dvhMfJ7dvEjfhlfQYYdEbRp/BsAAyyGSDs3GmxLSl4arOVNFztTsXNwvpt37el8CdZYdao9utl1/rZ+w==",
       "dev": true,
       "requires": {
         "applicationinsights": "^1.4.0",
@@ -6783,9 +6783,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
-      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==",
       "dev": true
     },
     "public-encrypt": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "office-addin-dev-certs": "^1.3.2",
     "office-addin-test-helpers": "^1.0.1",
     "office-addin-test-server": "^1.0.2",
-    "office-toolbox": "^0.2.1",
+    "office-toolbox": "^0.3.0",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.0.4",
     "ts-node": "^8.3.0",


### PR DESCRIPTION
office-toolbox@0.3.0 is currently published using the "next" dist-tag. This is to validate that it is OK to publish as latest and update the templates to use it.