### PR TITLE
ensure production build contains assets

### DIFF
--- a/src/taskpane/excel.ts
+++ b/src/taskpane/excel.ts
@@ -3,6 +3,11 @@
  * See LICENSE in the project root for license information.
  */
 
+// images references in the manifest
+import "../../assets/icon-16.png";
+import "../../assets/icon-32.png";
+import "../../assets/icon-80.png";
+
 /* global console, document, Excel, Office */
 
 Office.onReady(info => {

--- a/src/taskpane/onenote.ts
+++ b/src/taskpane/onenote.ts
@@ -3,6 +3,11 @@
  * See LICENSE in the project root for license information.
  */
 
+// images references in the manifest
+import "../../assets/icon-16.png";
+import "../../assets/icon-32.png";
+import "../../assets/icon-80.png";
+
 /* global document, Office */
 
 Office.onReady(info => {

--- a/src/taskpane/outlook.ts
+++ b/src/taskpane/outlook.ts
@@ -3,6 +3,11 @@
  * See LICENSE in the project root for license information.
  */
 
+// images references in the manifest
+import "../../assets/icon-16.png";
+import "../../assets/icon-32.png";
+import "../../assets/icon-80.png";
+
 /* global document, Office */
 
 Office.onReady(info => {

--- a/src/taskpane/powerpoint.ts
+++ b/src/taskpane/powerpoint.ts
@@ -3,6 +3,11 @@
  * See LICENSE in the project root for license information.
  */
 
+// images references in the manifest
+import "../../assets/icon-16.png";
+import "../../assets/icon-32.png";
+import "../../assets/icon-80.png";
+
 /* global console, document, Office */
 
 Office.onReady(info => {

--- a/src/taskpane/project.ts
+++ b/src/taskpane/project.ts
@@ -3,6 +3,11 @@
  * See LICENSE in the project root for license information.
  */
 
+// images references in the manifest
+import "../../assets/icon-16.png";
+import "../../assets/icon-32.png";
+import "../../assets/icon-80.png";
+
 /* global console document, Office */
 
 Office.onReady(info => {

--- a/src/taskpane/word.ts
+++ b/src/taskpane/word.ts
@@ -3,6 +3,11 @@
  * See LICENSE in the project root for license information.
  */
 
+// images references in the manifest
+import "../../assets/icon-16.png";
+import "../../assets/icon-32.png";
+import "../../assets/icon-80.png";
+
 /* global document, Office, Word */
 
 Office.onReady(info => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,8 +5,12 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const fs = require("fs");
 const webpack = require("webpack");
 
+const urlDev="https://localhost:3000/";
+const urlProd="https://www.contoso.com/"; // CHANGE THIS TO YOUR PRODUCTION DEPLOYMENT LOCATION
+
 module.exports = async (env, options) => {
   const dev = options.mode === "development";
+  const buildType = dev ? "dev" : "prod";
   const config = {
     devtool: "source-map",
     entry: {
@@ -36,7 +40,10 @@ module.exports = async (env, options) => {
         },
         {
           test: /\.(png|jpg|jpeg|gif)$/,
-          use: "file-loader"
+          loader: "file-loader",
+          options: {
+            name: '[path][name].[ext]',          
+          }
         }
       ]
     },
@@ -51,6 +58,17 @@ module.exports = async (env, options) => {
         {
           to: "taskpane.css",
           from: "./src/taskpane/taskpane.css"
+        },
+        {
+          to: "[name]." + buildType + ".[ext]",
+          from: "manifest*.xml",
+          transform(content) {
+            if (dev) {
+              return content;
+            } else {
+              return content.toString().replace(new RegExp(urlDev, "g"), urlProd);
+            }
+          }
         }
       ]),
       new HtmlWebpackPlugin({


### PR DESCRIPTION
Currently, production builds output the assets files using the hash for the file name, and do not include assets that are in the manifest but not referenced in the code.

Change the webpack config so the output path for assets keeps the original folder path, and add a reference in the code to icons in the manifest so they will also be in the build output.