### PR TITLE
"https://" in AppDomain

### DIFF
--- a/manifest.outlook.xml
+++ b/manifest.outlook.xml
@@ -14,7 +14,7 @@
   <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/icon-80.png"/>
   <SupportUrl DefaultValue="https://www.contoso.com/help"/>
   <AppDomains>
-    <AppDomain>contoso.com</AppDomain>
+    <AppDomain>https://www.contoso.com</AppDomain>
   </AppDomains>
   <Hosts>
     <Host Name="Mailbox" />


### PR DESCRIPTION
This to avoid parsing issues when developer adds AppDomains without "https://".