### PR TITLE
no need to use Promise in async methods

### DIFF
--- a/test/src/excel-test-taskpane.ts
+++ b/test/src/excel-test-taskpane.ts
@@ -14,28 +14,21 @@ Office.onReady(async (info) => {
 });
 
 export async function runTest(): Promise<void> {
-    return new Promise<void>(async (resolve, reject) => {
-        try {
-            // Execute taskpane code
-            await run();
-            await testHelpers.sleep(2000);
+    // Execute taskpane code
+    await run();
+    await testHelpers.sleep(2000);
 
-            // Get output of executed taskpane code
-            await Excel.run(async context => {
-                const range = context.workbook.getSelectedRange();
-                const cellFill = range.format.fill;
-                cellFill.load('color');
-                await context.sync();
-                await testHelpers.sleep(2000);
+    // Get output of executed taskpane code
+    return Excel.run(async context => {
+        const range = context.workbook.getSelectedRange();
+        const cellFill = range.format.fill;
+        cellFill.load('color');
+        await context.sync();
+        await testHelpers.sleep(2000);
 
-                testHelpers.addTestResult(testValues, "fill-color", cellFill.color, "#FFFF00");
-                await sendTestResults(testValues, port);
-                testValues.pop();
-                await testHelpers.closeWorkbook();
-                resolve();
-            });
-        } catch {
-            reject();
-        }
+        testHelpers.addTestResult(testValues, "fill-color", cellFill.color, "#FFFF00");
+        await sendTestResults(testValues, port);
+        testValues.pop();
+        await testHelpers.closeWorkbook();
     });
 }

--- a/test/src/word-test-taskpane.ts
+++ b/test/src/word-test-taskpane.ts
@@ -14,26 +14,19 @@ Office.onReady(async(info) => {
 });
 
 export async function runTest() {
-    return new Promise<void>(async (resolve, reject) => {
-        try {
-            // Execute taskpane code
-            await run();
-            await testHelpers.sleep(2000);
+    // Execute taskpane code
+    await run();
+    await testHelpers.sleep(2000);
 
-            // Get output of executed taskpane code
-            Word.run(async (context) => {
-                var firstParagraph = context.document.body.paragraphs.getFirst();
-                firstParagraph.load("text");
-                await context.sync();
-                await testHelpers.sleep(2000);
+    // Get output of executed taskpane code
+    return Word.run(async (context) => {
+        var firstParagraph = context.document.body.paragraphs.getFirst();
+        firstParagraph.load("text");
+        await context.sync();
+        await testHelpers.sleep(2000);
 
-                testHelpers.addTestResult(testValues, "output-message", firstParagraph.text, "Hello World");
-                await sendTestResults(testValues, port);
-                testValues.pop();
-                resolve();
-            });
-        } catch {
-            reject();
-        }
+        testHelpers.addTestResult(testValues, "output-message", firstParagraph.text, "Hello World");
+        await sendTestResults(testValues, port);
+        testValues.pop();
     });
 }


### PR DESCRIPTION
I noticed this after when reviewing content add-in changes. Also, there is a missing await For Word.run() (but not Excel) which I optimized by returning the last promise rather than awaiting it. I wonder if this could help avoid some sleeps in the code since I think this could cause the test to return earlier instead of waiting for the Office.js code to execute.