### PR TITLE
Adding PowerPoint Test for Taskpane

### DIFF
--- a/src/taskpane/powerpoint.ts
+++ b/src/taskpane/powerpoint.ts
@@ -22,15 +22,20 @@ export async function run() {
   /**
    * Insert your PowerPoint code here
    */
-  Office.context.document.setSelectedDataAsync(
-    "Hello World!",
-    {
-      coercionType: Office.CoercionType.Text
-    },
-    result => {
-      if (result.status === Office.AsyncResultStatus.Failed) {
-        console.error(result.error.message);
+
+  return new Promise<void>((resolve, reject) => {
+    Office.context.document.setSelectedDataAsync(
+      "Hello World!",
+      {
+        coercionType: Office.CoercionType.Text
+      },
+      result => {
+        if (result.status === Office.AsyncResultStatus.Failed) {
+          console.error(result.error.message);
+          reject(result.error);
+        }
+        resolve();
       }
-    }
-  );
+    );
+  });
 }

--- a/test/src/powerpoint-test-taskpane.ts
+++ b/test/src/powerpoint-test-taskpane.ts
@@ -1,0 +1,34 @@
+import { pingTestServer, sendTestResults } from "office-addin-test-helpers";
+import { run } from "../../src/taskpane/powerpoint";
+import * as testHelpers from "./test-helpers";
+const port: number = 4201;
+let testValues: any = [];
+
+Office.onReady(async (info) => {
+    if (info.host === Office.HostType.PowerPoint) {
+        const testServerResponse: object = await pingTestServer(port);
+        if (testServerResponse["status"] == 200) {
+            runTest();
+        }
+    }
+});
+
+export async function runTest(): Promise<void> {
+    // Execute taskpane code
+    await run();
+    await run();
+    await testHelpers.sleep(6000);
+
+    // Get output of executed taskpane code
+    return Office.context.document.getSelectedDataAsync(Office.CoercionType.Text, async (asyncResult) => {
+        if (asyncResult.status === Office.AsyncResultStatus.Failed) {
+            console.error(asyncResult.error.message);
+            testHelpers.addTestResult(testValues, "output-message", asyncResult.error.message, " Hello World!");
+        } else {
+            console.log(`The selected data is "${asyncResult.value}".`);
+            testHelpers.addTestResult(testValues, "output-message", asyncResult.value, " Hello World!");
+        }
+        await sendTestResults(testValues, port);
+        testValues.pop();
+    });
+}

--- a/test/src/powerpoint-test-taskpane.ts
+++ b/test/src/powerpoint-test-taskpane.ts
@@ -14,21 +14,43 @@ Office.onReady(async (info) => {
 });
 
 export async function runTest(): Promise<void> {
+    // Set up textbox and cursor for taskpane code test
+    await new Promise<void>((resolve, reject) => {
+        Office.context.document.setSelectedDataAsync(
+            " ",
+            {
+                coercionType: Office.CoercionType.Text
+            },
+            result => {
+                if (result.status === Office.AsyncResultStatus.Failed) {
+                    console.error(result.error.message);
+                    reject(result.error);
+                }
+                resolve();
+            }
+        )
+    });
+
     // Execute taskpane code
     await run();
-    await run();
     await testHelpers.sleep(6000);
+    await actualTest();
+}
 
+async function actualTest() {
     // Get output of executed taskpane code
-    return Office.context.document.getSelectedDataAsync(Office.CoercionType.Text, async (asyncResult) => {
-        if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-            console.error(asyncResult.error.message);
-            testHelpers.addTestResult(testValues, "output-message", asyncResult.error.message, " Hello World!");
-        } else {
-            console.log(`The selected data is "${asyncResult.value}".`);
-            testHelpers.addTestResult(testValues, "output-message", asyncResult.value, " Hello World!");
-        }
-        await sendTestResults(testValues, port);
-        testValues.pop();
+    return new Promise<void>((resolve) => {
+        Office.context.document.getSelectedDataAsync(Office.CoercionType.Text, async (asyncResult) => {
+            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
+                console.error(asyncResult.error.message);
+                testHelpers.addTestResult(testValues, "output-message", asyncResult.error.message, "Hello World!");
+            } else {
+                console.log(`The selected data is "${asyncResult.value}".`);
+                testHelpers.addTestResult(testValues, "output-message", asyncResult.value, "Hello World!");
+            }
+            await sendTestResults(testValues, port);
+            testValues.pop();
+            resolve();
+        });
     });
 }

--- a/test/src/test-helpers.ts
+++ b/test/src/test-helpers.ts
@@ -8,7 +8,7 @@ export async function closeDesktopApplication(application: string): Promise<bool
             processName = "Excel";
             break;
         case "powerpoint":
-            processName = (process.platform === "win32") ? "Powerpnt" : "Powerpoint";
+            processName = (process.platform === "win32") ? "Powerpnt" : "PowerPoint";
             break;
         case "onenote":
             processName = "Onenote";

--- a/test/src/test-taskpane.ts
+++ b/test/src/test-taskpane.ts
@@ -1,3 +1,3 @@
 import "./excel-test-taskpane";
-import "./word-test-taskpane";
 import "./powerpoint-test-taskpane";
+import "./word-test-taskpane";

--- a/test/src/test-taskpane.ts
+++ b/test/src/test-taskpane.ts
@@ -1,2 +1,3 @@
 import "./excel-test-taskpane";
-import "./word-test-taskpane"; 
+import "./word-test-taskpane";
+import "./powerpoint-test-taskpane";

--- a/test/ui-test.ts
+++ b/test/ui-test.ts
@@ -21,8 +21,8 @@ hosts.forEach(function (host) {
             // Start test server and ping to ensure it's started
             const testServerStarted = await testServer.startTestServer(true /* mochaTest */);
             const serverResponse = await officeAddinTestHelpers.pingTestServer(testServerPort);
-            assert.equal(testServerStarted, true);
-            assert.equal(serverResponse["status"], 200);
+            assert.strictEqual(testServerStarted, true);
+            assert.strictEqual(serverResponse["status"], 200);
 
             // Call startDebugging to start dev-server and sideload
             const devServerCmd = `npm run dev-server -- --config ./test/webpack.config.js `;
@@ -34,25 +34,25 @@ hosts.forEach(function (host) {
             it("Validate expected result count", async function () {
                 this.timeout(0);
                 testValues = await testServer.getTestResults();
-                assert.equal(testValues.length > 0, true);
+                assert.strictEqual(testValues.length > 0, true);
             });
             it("Validate expected result name", async function () {
-                assert.equal(testValues[0].resultName, host.toLowerCase() === "excel" ? "fill-color" : "output-message");
+                assert.strictEqual(testValues[0].resultName, host.toLowerCase() === "excel" ? "fill-color" : "output-message");
             });
             it("Validate expected result", async function () {
-                assert.equal(testValues[0].resultValue, testValues[0].expectedValue);
+                assert.strictEqual(testValues[0].resultValue, testValues[0].expectedValue);
             });
         });
         after(`Teardown test environment and shutdown ${host}`, async function () {
             this.timeout(0);
             // Stop the test server
             const stopTestServer = await testServer.stopTestServer();
-            assert.equal(stopTestServer, true);
+            assert.strictEqual(stopTestServer, true);
 
             // Close desktop application for all apps but Excel, which has it's own closeWorkbook API
             if (host != 'Excel') {
                 const applicationClosed = await testHelpers.closeDesktopApplication(host);
-                assert.equal(applicationClosed, true);
+                assert.strictEqual(applicationClosed, true);
             }
         });
     });

--- a/test/ui-test.ts
+++ b/test/ui-test.ts
@@ -49,11 +49,6 @@ hosts.forEach(function (host) {
             const stopTestServer = await testServer.stopTestServer();
             assert.equal(stopTestServer, true);
 
-            // Unregister the add-in
-            if (host == hosts[hosts.length - 1]) {
-                await stopDebugging(manifestPath);
-            }
-
             // Close desktop application for all apps but Excel, which has it's own closeWorkbook API
             if (host != 'Excel') {
                 const applicationClosed = await testHelpers.closeDesktopApplication(host);
@@ -63,8 +58,6 @@ hosts.forEach(function (host) {
     });
 });
 
-after(`Unregister the add-in`, callback => {
-    stopDebugging(manifestPath).then(() => {
-        setImmediate(callback);
-    });
+after(`Unregister the add-in`, async function () {
+    return stopDebugging(manifestPath);
 });

--- a/test/ui-test.ts
+++ b/test/ui-test.ts
@@ -7,7 +7,7 @@ import * as officeAddinTestHelpers from "office-addin-test-helpers";
 import * as officeAddinTestServer from "office-addin-test-server";
 import * as path from "path";
 import * as testHelpers from "./src/test-helpers";
-const hosts = ["Excel", "Word", "PowerPoint"];
+const hosts = ["Excel", "PowerPoint", "Word"];
 const manifestPath = path.resolve(`${process.cwd()}/test/test-manifest.xml`);
 const testServerPort: number = 4201;
 
@@ -61,4 +61,8 @@ hosts.forEach(function (host) {
             }
         });
     });
+});
+
+after(`Unregister the add-in`, async function () {
+    return stopDebugging(manifestPath);
 });

--- a/test/ui-test.ts
+++ b/test/ui-test.ts
@@ -63,6 +63,8 @@ hosts.forEach(function (host) {
     });
 });
 
-after(`Unregister the add-in`, async function () {
-    return stopDebugging(manifestPath);
+after(`Unregister the add-in`, callback => {
+    stopDebugging(manifestPath).then(() => {
+        setImmediate(callback);
+    });
 });

--- a/test/ui-test.ts
+++ b/test/ui-test.ts
@@ -7,7 +7,7 @@ import * as officeAddinTestHelpers from "office-addin-test-helpers";
 import * as officeAddinTestServer from "office-addin-test-server";
 import * as path from "path";
 import * as testHelpers from "./src/test-helpers";
-const hosts = ["Excel", "Word"];
+const hosts = ["Excel", "Word", "PowerPoint"];
 const manifestPath = path.resolve(`${process.cwd()}/test/test-manifest.xml`);
 const testServerPort: number = 4201;
 
@@ -50,7 +50,9 @@ hosts.forEach(function (host) {
             assert.equal(stopTestServer, true);
 
             // Unregister the add-in
-            await stopDebugging(manifestPath);
+            if (host == hosts[hosts.length - 1]) {
+                await stopDebugging(manifestPath);
+            }
 
             // Close desktop application for all apps but Excel, which has it's own closeWorkbook API
             if (host != 'Excel') {


### PR DESCRIPTION
There is also a small change to the test runner to only shut off the test server once the very last host has been tested. Otherwise, there's an issue where the dev server closes and doesn't reopen before the next host gets tested. This issue hasn't been encountered before, since it's only a problem if the previous host wasn't Excel. We only previously tested Excel and Word (in that order), so this includes a small change to accommodate that issue for including another host.