### PR TITLE
fix package.json to allow changing dev-server port

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   },
   "license": "MIT",
   "config": {
-    "app-to-debug": "excel",
-    "app-type-to-debug": "desktop",
-    "dev-server-port": 3000
+    "app_to_debug": "excel",
+    "app_type_to_debug": "desktop",
+    "dev_server_port": 3000
   },
   "scripts": {
     "build": "webpack -p --mode production --https false",


### PR DESCRIPTION
The package.json config values need to use underscores instead of hyphens.
I think "npm run" might have done this conversion but it isn't happening now.