### PR TITLE
BugFix: Making debugging web via vscode work again

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -95,10 +95,6 @@
       "name": "Office Online (Chrome)",
       "type": "chrome",
       "request": "launch",
-      // To debug your Add-in:
-      // 1. When prompted, enter the url (share link) to an Office Online document.
-      // 2. Sideload your Add-in. https://docs.microsoft.com/en-us/office/dev/add-ins/testing/sideload-office-add-ins-for-testing
-      "url": "${input:officeOnlineDocumentUrl}",
       "webRoot": "${workspaceFolder}",
       "preLaunchTask": "Debug: Web"
     },
@@ -107,19 +103,8 @@
       "type": "pwa-msedge",
       "request": "launch",
       "port": 9222,
-      // To debug your Add-in:
-      // 1. When prompted, enter the url (share link) to an Office Online document.
-      // 2. Sideload your Add-in. https://docs.microsoft.com/en-us/office/dev/add-ins/testing/sideload-office-add-ins-for-testing
-      "url": "${input:officeOnlineDocumentUrl}",
       "webRoot": "${workspaceFolder}",
       "preLaunchTask": "Debug: Web"
-    }
-  ],
-  "inputs": [
-    {
-      "id": "officeOnlineDocumentUrl",
-      "type": "promptString",
-      "description": "Please enter the url for the Office Online document."
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -59,9 +59,12 @@
       "problemMatcher": []
     },
     {
+      // To debug your Add-in:
+      // 1. When prompted, enter the url (share link) to an Office Online document.
+      // 2. Sideload your Add-in. https://docs.microsoft.com/en-us/office/dev/add-ins/testing/sideload-office-add-ins-for-testing
       "label": "Debug: Web",
       "type": "npm",
-      "script": "start:web",
+      "script": "start:web -- --document ${input:officeOnlineDocumentUrl}",
       "presentation": {
         "clear": true,
         "panel": "shared",
@@ -130,5 +133,12 @@
       },
       "problemMatcher": []
     },
+  ],
+  "inputs": [
+    {
+      "id": "officeOnlineDocumentUrl",
+      "type": "promptString",
+      "description": "Please enter the url for the Office Online document."
+    }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -243,7 +243,7 @@
       }
     },
     "../Office-Addin-Scripts/packages/office-addin-lint": {
-      "version": "1.0.32",
+      "version": "1.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Tested by running the debug command from VSCode interface and it correctly opens and loads the add-in for debugging in the web.

**That was originally the bug:**
VScode prompts for the url and this url is not passed to the ```start:web``` command.

Steps to reproduce:
1. Create a new web office document
2. Copy the shared link url of the document
3. Go the vs code, open debug panel and run Office Online (can be Chrome or Edge)
4. When it prompts for the url, paste the shared link
Result:
```Debugging is being started...
App type: web
Sideloading the Office Add-in...
Error: Unable to start debugging.
office-addin-debugging: Unable to sideload the Office Add-in.  
Error: For sideload to web, you need to specify a document url.```

Expect:
It should sideload successfully and open the page