### PR TITLE
Fix reference to test manifest in pipeline.

### DIFF
--- a/.azure-devops/test.yml
+++ b/.azure-devops/test.yml
@@ -10,7 +10,7 @@ steps:
         
         echo Setting WebView Type: ${{ parameters.webView }}
         call npx office-addin-dev-settings webview manifest.xml ${{ parameters.webView }}
-        call npx office-addin-dev-settings webview test/test-manifest.xml ${{ parameters.webView }}
+        call npx office-addin-dev-settings webview test/end-to-end/test-manifest.xml ${{ parameters.webView }}
         
         echo Running Tests
         npm run test


### PR DESCRIPTION
When unit tests were added the location of the manifest referenced in the pipeline changed.  The pipeline needed to be updated to reference it at the correct place.