### PR TITLE
Add pause before closing workbook

### DIFF
--- a/test/end-to-end/src/test-helpers.ts
+++ b/test/end-to-end/src/test-helpers.ts
@@ -42,6 +42,7 @@ export async function closeDesktopApplication(application: string): Promise<bool
 }
 
 export async function closeWorkbook(): Promise<void> {
+  await sleep(1000);
   await Excel.run(async (context) => context.workbook.close(Excel.CloseBehavior.skipSave));
 }
 


### PR DESCRIPTION
Mac CI machines were failing because things hung after the call to close the workbook was called (like it never returned from the call).  Adding a pause before the call seems to let Excel "settle" and the call to go through.