### PR TITLE
Fixing sideloading on Web not finding manifest file

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,6 @@ async function getHttpsOptions() {
 
 module.exports = async (env, options) => {
   const dev = options.mode === "development";
-  const buildType = dev ? "dev" : "prod";
   const config = {
     devtool: "source-map",
     entry: {
@@ -74,7 +73,7 @@ module.exports = async (env, options) => {
           },
           {
             from: "manifest*.xml",
-            to: "[name]." + buildType + "[ext]",
+            to: "[name]" + "[ext]",
             transform(content) {
               if (dev) {
                 return content;


### PR DESCRIPTION
Sideloading in the web was not working because we modified the manifest name to `manifest.dev.xml` and this modification is not expected by `office-addin-dev-settings`, which always looks for the manifest path.
