### PR TITLE
Add postinstall .Net check

### DIFF
--- a/checkDotNet.js
+++ b/checkDotNet.js
@@ -1,0 +1,22 @@
+const chalk = require("chalk");
+const childProcess = require("child_process");
+
+/* global console require */
+
+try {
+  // Find the .Net runtimes installed
+  let result = childProcess.execSync("dotnet --list-runtimes");
+  const pattern = /(?<=Microsoft.NETCore.App )[\d.]+/g;
+  const matches = result.toString("utf-8").match(pattern);
+  let foundDotNet = false;
+
+  // Look for version 5 or greater
+  matches?.forEach((match) => {
+    const major = parseInt(match.split(".")[0]);
+    foundDotNet = foundDotNet || major >= 5;
+  });
+
+  console.log("Correct version of .Net is installed");
+} catch (err) {
+  console.log(chalk.bold.red(".Net 5 or greater is required for json manifests."));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "office-addin-taskpane",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dev-server": "webpack serve --mode development",
     "lint": "office-addin-lint check",
     "lint:fix": "office-addin-lint fix",
+    "postinstall": "node checkDotNet.js",
     "prettier": "office-addin-lint prettier",
     "start": "office-addin-debugging start manifest/manifest.json",
     "start:desktop": "office-addin-debugging start manifest/manifest.json desktop",


### PR DESCRIPTION
This will indicate weather or not .Net is installed (needed by the template) at the end of running 'npm install'