### PR TITLE
Add local schema

### DIFF
--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,7 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
+  "$schema": "metaos.schema.json",
   "id": "f2b103f1-1ab1-4e1b-8f0b-072aa3d4e19d",
-  "manifestVersion": "m365DevPreview",
   "version": "1.0.0",
   "name": {
     "short": "Contoso Task Pane Add-in",
@@ -13,7 +12,7 @@
   },
   "publisher": {
     "name": "Contoso",
-    "websiteUrl": "https://www.contoso.com",
+    "webSiteUrl": "https://www.contoso.com",
     "privacyUrl": "https://www.contoso.com/privacy",
     "termsOfUseUrl": "https://www.contoso.com/servicesagreement",
     "supportUrl": "https://www.contoso.com/help"
@@ -24,20 +23,9 @@
   },
   "accentColor": "#230201",
   "localization": {
-    "defaultLanguageTag": "en-us",
+    "defaultLanguage": "en-us",
     "additionalLanguages": []
   },
-  "authorization": {
-    "permissions": {
-      "resourceSpecific": [
-        {
-          "name": "Mailbox.ReadWrite",
-          "type": "Delegated"
-        }
-      ]
-    }
-  },
-  "validDomains": ["contoso.com"],
   "extension": {
     "requirements": {
       "scopes": ["mail"],
@@ -46,16 +34,6 @@
         { "name": "MailBox", "minVersion": "1.3" }
       ]
     },
-    "getStartedMessages": [
-      {
-        "requirements": {
-          "formFactors": ["desktop"]
-        },
-        "title": "Get Started",
-        "description": "Your sample add-in loaded succesfully. Click the buttons to get started.",
-        "learnMoreUrl": "https://www.contoso.com/learnmore"
-      }
-    ],
     "runtimes": [
       {
         "requirements": {

--- a/manifest/metaos.schema.json
+++ b/manifest/metaos.schema.json
@@ -1,0 +1,1064 @@
+{
+    "oneOf": [
+        { "$ref": "#/definitions/manifest" },
+        { "$ref": "#/definitions/element-runtimes" },
+        { "$ref": "#/definitions/element-keyboards" },
+        { "$ref": "#/definitions/element-autoTriggers" },
+        { "$ref": "#/definitions/element-contextMenus" },
+        { "$ref": "#/definitions/element-ribbons" }
+    ],
+
+
+    "definitions": {
+        "manifest": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "$schema": {
+                    "$ref": "#/definitions/base-url"
+                },
+                "id": {
+                    "$ref": "#/definitions/id"
+                },
+                "version": {
+                    "$ref": "#/definitions/version"
+                },
+                "name": {
+                    "$ref": "#/definitions/name"
+                },
+                "description": {
+                    "$ref": "#/definitions/description"
+                },
+                "icons": {
+                    "$ref": "#/definitions/icons"
+                },
+                "accentColor": {
+                    "$ref": "#/definitions/accentColor"
+                },
+                "publisher": {
+                    "$ref": "#/definitions/publisher"
+                },
+                "localization": {
+                    "$ref": "#/definitions/localization"
+                },
+                "extension": {
+                    "$ref": "#/definitions/extension"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "version",
+                "name",
+                "description",
+                "icons",
+                "accentColor",
+                "publisher",
+                "extension"
+            ]
+        },
+        "id": {
+            "$ref": "#/definitions/base-guid",
+            "description": "A unique identifier for this app. This id must be a GUID (without any enclosing decoration.)"
+        },
+        "version": {
+            "$ref": "#/definitions/base-version",
+            "description": "The version of the app. Changes to your manifest should cause a version change. This version string must follow the semver standard (http://semver.org)."
+        },
+        "name": {
+            "type": "object",
+            "properties": {
+                "short": {
+                    "type": "string",
+                    "description": "A short display name for the app. Maximum length is 30 characters.",
+                    "maxLength": 30
+                },
+                "long": {
+                    "type": "string",
+                    "description": "The full name of the app. Maximum length is 150 characters.",
+                    "maxLength": 150
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "short"
+            ]
+        },
+        "description": {
+            "type": "object",
+            "properties": {
+                "short": {
+                    "type": "string",
+                    "description": "A short description of the app used when space is limited. Maximum length is 80 characters.",
+                    "maxLength": 80
+                },
+                "long": {
+                    "type": "string",
+                    "description": "The full description of the app. Maximum length is 4000 characters.",
+                    "maxLength": 4000
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "short",
+                "long"
+            ]
+        },
+        "icons": {
+            "type": "object",
+            "properties": {
+                "outline": {
+                    "$ref": "#/definitions/base-relative-path",
+                    "description": "A relative file path to a transparent PNG outline icon. The border color needs to be white. Size 32x32."
+                },
+                "color": {
+                    "$ref": "#/definitions/base-relative-path",
+                    "description": "A relative file path to a full color PNG icon. Size 192x192."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "outline",
+                "color"
+            ]
+        },
+        "accentColor": {
+            "$ref": "#/definitions/base-color",
+            "description": "A color to use in conjunction with the icons. The value must be a valid HTML color code starting with '#', for example `#4464ee`."
+        },
+        "publisher": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The display name of the publisher. Maximum length is 64 characters.",
+                    "maxLength": 64
+                },
+                "webSiteUrl": {
+                    "$ref": "#/definitions/base-url",
+                    "description": "The URL of the publisher's company or product-specific landing page."
+                },
+                "privacyUrl": {
+                    "$ref": "#/definitions/base-url",
+                    "description": "The URL of the page that provides information about user privacy."
+                },
+                "termsOfUseUrl": {
+                    "$ref": "#/definitions/base-url",
+                    "description": "The URL to the page that provides the terms of use for the app."
+                },
+                "supportUrl": {
+                    "$ref": "#/definitions/base-url",
+                    "description": "The URL of the page that provides support information for the app."
+                },
+                "mpnId": {
+                    "type": "string",
+                    "description": "The Microsoft Partner Network ID that identifies the partner organization building the app. This field is not required, and should only be used if you are already part of the Microsoft Partner Network. More info at https://aka.ms/partner",
+                    "maxLength": 10
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "name",
+                "webSiteUrl",
+                "privacyUrl",
+                "termsOfUseUrl",
+                "supportUrl"
+            ]
+        },
+        "localization": {
+            "type": "object",
+            "properties": {
+                "defaultLanguage": {
+                    "$ref": "#/definitions/base-language",
+                    "description": "The language tag of the strings in this top level manifest file.",
+                    "default": "en-us"
+                },
+                "additionalLanguages": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "language": {
+                                "$ref": "#/definitions/base-language",
+                                "description": "The language tag of the strings in the provided file."
+                            },
+                            "file": {
+                                "$ref": "#/definitions/base-relative-path",
+                                "description": "A relative file path to a .json file containing the translated strings."
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "language",
+                            "file"
+                        ]
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "defaultLanguage"
+            ]
+        },
+         "extension": {
+            "type": "object",
+            "properties": {
+                "requirements": {
+                    "$ref": "#/definitions/requirements"
+                },
+                "runtimes": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/base-relative-path" },
+                        { "$ref": "#/definitions/runtimes-array" }
+                    ]
+                },
+                "keyboards": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/base-relative-path" },
+                        { "$ref": "#/definitions/keyboards-array" }
+                    ]
+                },
+                "autoTriggers": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/base-relative-path" },
+                        { "$ref": "#/definitions/autoTriggers-array" }
+                    ]
+                },
+                "contextMenus": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/base-relative-path" },
+                        { "$ref": "#/definitions/contextMenus-array" }
+                    ]
+                },
+                "ribbons": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/base-relative-path" },
+                        { "$ref": "#/definitions/ribbons-array" }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+
+
+        "requirements": {
+            "type": "object",
+            "properties": {
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/base-scope"
+                    }
+                },
+                "capabilities": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "minVersion": {
+                                "type": "string"
+                            },
+                            "maxVersion": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "platforms": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/base-platform"
+                    }
+                },
+                "formFactors": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/base-formFactor"
+                    }
+                }
+            }
+        },
+        "contexts": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/base-context"
+            }
+        },
+
+
+        "element-runtimes": {
+            "type": "object",
+            "properties": {
+                "$schema": {
+                  "$ref": "#/definitions/base-url"
+                },
+                "runtimes": {
+                    "$ref": "#/definitions/runtimes-array"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "runtimes"
+            ]
+        },
+        "runtimes-array": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/runtimes-runtime"
+            }
+        },
+        "runtimes-runtime": {
+            "type": "object",
+            "description": "A runtime environment to execute a script",
+            "properties": {
+                "requirements": {
+                    "$ref": "#/definitions/requirements"
+                },
+                "contexts": {
+                    "$ref": "#/definitions/contexts"
+                },
+                "id": {
+                    "type": "string",
+                    "description": "App-wide unique ID. Maximum length is 30 characters.",
+                    "maxLength": 30
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "general",
+                        "content"
+                    ],
+                    "description": "General-type bundles can execute individual script functions as well as can launch pages. Content-type bundles can loach pages in 'floating' content views."
+                },
+                "code": {
+                    "type": "object",
+                    "properties": {
+                        "page": {
+                            "$ref": "#/definitions/base-url",
+                            "description": "URL of the .html page to be loaded in browser-based runtimes."
+                        },
+                        "script": {
+                            "$ref": "#/definitions/base-url",
+                            "description": "URL of the .js script file to be loaded in UI-less runtimes."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "page"
+                    ]
+                },
+                "lifetime": {
+                    "type": "string",
+                    "enum": ["short", "long"],
+                    "description": "Runtimes with a short lifetime do not preserve state across executions. Runtimes with a long lifetime do."
+                },
+                "actions": {
+                    "$ref": "#/definitions/runtimes-actions"
+                },
+                "functions": {
+                    "$ref": "#/definitions/runtimes-functions"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "type",
+                "code",
+                "lifetime",
+                "actions"
+            ]
+        },
+        "runtimes-actions": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            { "$ref": "#/definitions/runtimes-execution" },
+                            { "$ref": "#/definitions/runtimes-contextual-launch" },
+                            { "$ref": "#/definitions/runtimes-launch" }
+                        ]
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "items"
+            ]
+        },
+        "runtimes-execution": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "App-wide unique ID. Maximum length is 60 characters.",
+                    "maxLength": 60
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["execution"],
+                    "description": "Execute a script function without waiting for it to finish. No UI is shown."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the function from the bundle to be executed. Maximum length is 30 characters.",
+                    "maxLength": 30
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "type",
+                "name"
+            ]
+        },
+        "runtimes-contextual-launch": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "App-wide unique ID. Maximum length is 60 characters.",
+                    "maxLength": 60
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["contextual-launch"],
+                    "description": "Launch a page in a contextual view."
+                },
+                "view": {
+                    "type": "string",
+                    "description": "Logical ID of the view where the page should be launched. Different bundles can be launched in the same view at different times. Maximum length is 30 characters.",
+                    "maxLength": 30
+                },
+                "pinnable": {
+                    "type": "boolean",
+                    "description": "Specifies that a task pane supports pinning, which keeps the task pane open when the user changes the selection."
+                }
+
+            },
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "type",
+                "view"
+            ]
+        },
+        "runtimes-launch": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "App-wide unique ID. Maximum length is 60 characters.",
+                    "maxLength": 60
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["launch"],
+                    "description": "Launch a page in full-window mode."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "type"
+            ]
+        },
+        "runtimes-functions" : {
+            "type": "object",
+            "properties": {
+                "namespace": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "maxLength": 60,
+                            "description": "Non-localizeable version of the namespace."
+                        },
+                        "name": {
+                            "type": "string",
+                            "maxLength": 60,
+                            "description": "Localizeable version of the namespace."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id",
+                        "name"
+                    ]
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/runtimes-function"
+                    }
+                },
+                "allowErrorForDataTypeAny": {
+                    "type": "boolean",
+                    "description": "Whether RichError is allowed as a value for parameters of type any. Default: false."
+                },
+                "allowRichDataForDataTypeAny": {
+                    "type": "boolean",
+                    "description": "Whether RichData is allowed as a value for parameters of type any. Default: false."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "namespace",
+                "items"
+            ]
+        },
+        "runtimes-function": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "App-wide unique ID. Maximum length is 60 characters.",
+                    "maxLength": 60
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Display name. Maximum length is 30 characters.",
+                    "maxLength": 30
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Description of the functionality. Maximum length is 60 characters.",
+                    "maxLength": 60
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Display name. Maximum length is 30 characters.",
+                                "maxLength": 30
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Description of the parameter. Maximum length is 60 characters.",
+                                "maxLength": 60
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "boolean",
+                                    "number",
+                                    "string",
+                                    "any"
+                                ],
+                                "description": "Parameter type. Default: any."
+                            },
+                            "dimensionality": {
+                                "type": "string",
+                                "enum": [
+                                    "scalar",
+                                    "matrix"
+                                ],
+                                "description": "Parameter dimensionality."
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "result": {
+                    "type": "object",
+                    "properties": {
+                        "dimensionality": {
+                            "type": "string",
+                            "enum": [
+                                "scalar",
+                                "matrix"
+                            ],
+                            "description": "Result dimensionality. Default: scalar."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                    ]
+                },
+                "stream": {
+                    "type": "boolean",
+                    "description": "Whether the function returns a stream of values. Default: false."
+                },
+                "volatile": {
+                    "type": "boolean",
+                    "description": "Whether the function is volatile. Default: false."
+                },
+                "cancelable": {
+                    "type": "boolean",
+                    "description": "Whether the function can be canceled. Default: false."
+                },
+                "requiresAddress": {
+                    "type": "boolean",
+                    "description": "Whether the function needs the address of the cell where it is being used. Default: false."
+                },
+                "requiresParameterAddress": {
+                    "type": "boolean",
+                    "description": "Whether the function needs the address of an argument value. Default: false."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "name"
+            ]
+        },
+
+
+        "element-keyboards": {
+            "type": "object",
+            "properties": {
+                "$schema": {
+                  "$ref": "#/definitions/base-url"
+                },
+                "keyboards": {
+                    "$ref": "#/definitions/keyboards-array"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "keyboards"
+            ]
+        },
+        "keyboards-array": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/keyboards-keyboard"
+            }
+        },
+        "keyboards-keyboard": {
+            "type": "object",
+            "properties": {
+                "requirements": {
+                    "$ref": "#/definitions/requirements"
+                },
+                "contexts": {
+                    "$ref": "#/definitions/contexts"
+                },
+                "shortcuts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/keyboards-shortcut"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "shortcuts"
+            ]
+        },
+        "keyboards-shortcut": {
+            "type": "object",
+            "properties": {
+                "key": {
+                            "type": "string",
+                    "description": "Key combination. Maximum length is 60 characters.",
+                            "maxLength": 60
+                },
+                "actionId": {
+                    "type": "string",
+                    "description": "The ID of an execution-type action that handles this key combination. Maximum length is 60 characters.",
+                    "maxLength": 60
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "key",
+                "actionId"
+            ]
+        },
+
+
+        "element-autoTriggers": {
+            "type": "object",
+            "properties": {
+                "$schema": {
+                  "$ref": "#/definitions/base-url"
+                },
+                "autoTriggers": {
+                    "$ref": "#/definitions/autoTriggers-array"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "autoTriggers"
+            ]
+        },
+        "autoTriggers-array": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/autoTriggers-autoTrigger"
+            }
+        },
+        "autoTriggers-autoTrigger": {
+            "type": "object",
+            "properties": {
+                "requirements": {
+                    "$ref": "#/definitions/requirements"
+                },
+                "contexts": {
+                    "$ref": "#/definitions/contexts"
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/autoTriggers-event"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "events"
+            ]
+        },
+        "autoTriggers-event": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "$ref": "#/definitions/autoTriggers-eventId"
+                },
+                "actionId": {
+                    "type": "string",
+                    "description": "The ID of an execution-type action that handles this key combination. Maximum length is 60 characters.",
+                    "maxLength": 60
+                },
+                "options": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "sendMode": {
+                                "$ref": "#/definitions/autoTriggers-sendMode"
+                            }
+                        }
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "actionId"
+            ]
+        },
+        "autoTriggers-eventId": {
+            "type": "string",
+            "enum": [
+                "unknown",
+                "newMessageComposeCreated",
+                "newAppointmentOrganizerCreated",
+                "messageAttachmentsChanged",
+                "appointmentAttachmentsChanged",
+                "messageRecipientsChanged",
+                "appointmentAttendeesChanged",
+                "appointmentTimeChanged",
+                "appointmentRecurrenceChanged",
+                "infoBarDismissClicked",
+                "messageSending",
+                "appointmentSending",
+
+                "documentNew",
+                "documentOpen"
+            ]
+        },
+        "autoTriggers-sendMode": {
+            "type": "string",
+            "enum": [
+                "unknown",
+                "promptUser",
+                "softBlock",
+                "block"
+            ]
+        },
+
+        "element-contextMenus": {
+            "type": "object",
+            "properties": {
+                "$schema": {
+                    "$ref": "#/definitions/base-url"
+                },
+                "contextMenus": {
+                    "$ref": "#/definitions/contextMenus-array"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "contextMenus"
+            ]
+        },
+        "contextMenus-array": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/contextMenus-contextMenu"
+            }
+        },
+        "contextMenus-contextMenu": {
+            "type": "object",
+            "properties": {
+                "requirements": {
+                    "$ref": "#/definitions/requirements"
+                },
+                "contexts": {
+                    "$ref": "#/definitions/contexts"
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common-control"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "items"
+            ]
+        },
+
+
+        "element-ribbons": {
+            "type": "object",
+            "properties": {
+                "$schema": {
+                  "$ref": "#/definitions/base-url"
+                },
+                "ribbons": {
+                    "$ref": "#/definitions/ribbons-array"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "ribbons"
+            ]
+        },
+        "ribbons-array": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/ribbons-ribbon"
+            }
+        },
+        "ribbons-ribbon": {
+            "type": "object",
+            "properties": {
+                "requirements": {
+                    "$ref": "#/definitions/requirements"
+                },
+                "contexts": {
+                    "$ref": "#/definitions/contexts"
+                },
+                "tabs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ribbons-tab"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "tabs"
+            ]
+        },
+        "ribbons-tab": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "App-wide unique ID. Maximum length is 30 characters.",
+                    "maxLength": 30
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Short label of the tab. Maximum length is 30 characters.",
+                    "maxLength": 30
+                },
+                "visible": {
+                    "type": "boolean",
+                    "description": "Whether the tab is initially visible."
+                },
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common-group"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "groups"
+            ]
+        },
+
+
+        "common-group": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "App-wide unique ID. Maximum length is 30 characters.",
+                    "maxLength": 30
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Short label of the group. Maximum length is 30 characters.",
+                    "maxLength": 30
+                },
+                "icons": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common-icon"
+                    }
+                },
+                "controls": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common-control"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "label",
+                "controls"
+            ]
+        },
+        "common-control": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "App-wide unique ID. Maximum length is 30 characters.",
+                    "maxLength": 30
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [ "button", "menuItem" ]
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Short label of the control. Maximum length is 30 characters.",
+                    "maxLength": 30
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether the control is initially enabled."
+                },
+                "icons": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common-icon"
+                    }
+                },
+                "tooltip": {
+                    "type": "string",
+                    "description": "Tooltip to show when the mouse hovers over the control. Maximum length is 60 characters.",
+                    "maxLength": 60
+                },
+                "supertip": {
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "description": "Title of the super tip. Maximum length is 30 characters.",
+                            "maxLength": 30
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "Description of the super tip. Maximum length is 100 characters.",
+                            "maxLength": 100
+                        }
+                    }
+                },
+                "actionId": {
+                    "type": "string",
+                    "description": "The ID of an execution-type action that handles this key combination. Maximum length is 60 characters.",
+                    "maxLength": 60
+                }
+            },
+            "required": [
+                "id",
+                "type",
+                "label"
+            ]
+        },
+        "common-icon": {
+            "type": "object",
+            "properties": {
+                "size": {
+                    "type": "number",
+                    "description": "Size in pixels of the side of the icon, e.g. 32, 64, 128."
+                },
+                "file": {
+                    "$ref": "#/definitions/base-relative-path",
+                    "description": "Relative path to the file that contains the icon."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "size",
+                "file"
+            ]
+        },
+
+
+        "base-scope": {
+            "type": "string",
+            "enum": [ "mail", "workbook", "document", "presentation", "chat", "team" ]
+        },
+        "base-context": {
+            "type": "string",
+            "enum": [ "default", "readMail", "composeMail" ]
+        },
+        "base-platform": {
+            "type": "string",
+            "enum": [ "windows", "mac", "web", "ios", "android" ]
+        },
+        "base-formFactor": {
+            "type": "string",
+            "enum": [ "desktop", "tablet", "phone" ]
+        },
+        "base-guid": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+        },
+        "base-version": {
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "base-color": {
+            "type": "string",
+            "pattern": "^\\#[0-9a-fA-F]{6}$"
+        },
+        "base-language": {
+            "type": "string",
+            "pattern": "^[a-zA-Z]{2}\\-[a-zA-Z]{2}$"
+        },
+        "base-relative-path": {
+            "type": "string",
+            "maxLength": 2048
+        },
+        "base-url": {
+            "type": "string",
+            "maxLength": 2048,
+            "format": "uri",
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://.+"
+        },
+        "base-comment": {
+            "type": "string",
+            "maxLength": 240
+        }
+    }
+}


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:

Adding schema information for the json manifest

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
    no

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
    No


3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
    Will output a local schema file for the manifest.json validation


4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    New documentation still to be written


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Ran template locally.
