### PR TITLE
Use newer version of fabric.min.css

### DIFF
--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -14,7 +14,7 @@
     <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
 
     <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui#/. -->
-    <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
+    <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/fabric.min.css"/>
 
     <!-- Template styles -->
     <link href="taskpane.css" rel="stylesheet" type="text/css" />

--- a/test/end-to-end/src/test-taskpane.html
+++ b/test/end-to-end/src/test-taskpane.html
@@ -14,7 +14,7 @@
     <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/beta/hosted/office.js"></script>
 
     <!-- For more information on Office UI Fabric, visit https://developer.microsoft.com/fabric. -->
-    <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
+    <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/fabric.min.css"/>
 
     <!-- Template styles -->
     <link href="../../../src/taskpane/taskpane.css" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:

    Updating the css reference used in the taskpane.html file

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
    No


2. **Do these changes impact *VS Code debugging* options (launch.json)?**
    No


3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
    Yes.  The css link in the html will point to a new file


4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    Probably not.


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Manual ran the taskpane and ran the tests locally.
