### PR TITLE
Wait for host before killing process

### DIFF
--- a/test/end-to-end/src/test-helpers.ts
+++ b/test/end-to-end/src/test-helpers.ts
@@ -27,6 +27,7 @@ export async function closeDesktopApplication(application: string): Promise<bool
       throw new Error(`${application} is not a valid Office desktop application.`);
   }
 
+  await sleep(3000); // wait for host to settle
   try {
     let cmdLine: string;
     if (process.platform == "win32") {


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:
When Excel tests complete we need to close the workbook before the host, but we kill the process to quickly.  We need to wait for Excel (and other hosts) before killing the process.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
    No.

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
    No.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
    No.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Ran automated tests multiple times.