### PR TITLE
Remove package-lock.json when convertToSingleHost.js script is run

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -167,6 +167,7 @@ async function deleteSupportFiles() {
   await unlinkFileAsync("README.md");
   await unlinkFileAsync("./convertToSingleHost.js");
   await unlinkFileAsync(".npmrc");
+  await unlinkFileAsync("package-lock.json");
 }
 
 /**


### PR DESCRIPTION
Removing the `package-lock.json` file when giving the template to customers in order to make the template work for other OS.

---

**Change Description**:

    Describe what the PR is about. 

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
    If Yes, briefly describe what is impacted.
No

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
    If Yes, briefly describe what is impacted.
No

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
We are now removing the lock file.


4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No
