### PR TITLE
VS Code launch.json no longer needs useWebView

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,9 +21,7 @@
         "${workspaceFolder}/test/end-to-end/*.ts"
       ],
       "internalConsoleOptions": "openOnSessionStart",
-      "runtimeArgs": [
-        "--preserve-symlinks"
-      ]
+      "runtimeArgs": ["--preserve-symlinks"]
     },
     {
       "name": "Debug Unit Tests",
@@ -42,15 +40,12 @@
         "${workspaceFolder}/test/unit/*.test.ts"
       ],
       "internalConsoleOptions": "openOnSessionStart",
-      "runtimeArgs": [
-        "--preserve-symlinks"
-      ]
+      "runtimeArgs": ["--preserve-symlinks"]
     },
     {
       "name": "Excel Desktop (Edge Chromium)",
       "type": "msedge",
       "request": "attach",
-      "useWebView": true,
       "port": 9229,
       "timeout": 600000,
       "webRoot": "${workspaceRoot}",
@@ -72,7 +67,6 @@
       "name": "Outlook Desktop (Edge Chromium)",
       "type": "msedge",
       "request": "attach",
-      "useWebView": true,
       "port": 9229,
       "timeout": 600000,
       "webRoot": "${workspaceRoot}",
@@ -94,7 +88,6 @@
       "name": "PowerPoint Desktop (Edge Chromium)",
       "type": "msedge",
       "request": "attach",
-      "useWebView": true,
       "port": 9229,
       "timeout": 600000,
       "webRoot": "${workspaceRoot}",
@@ -116,7 +109,6 @@
       "name": "Word Desktop (Edge Chromium)",
       "type": "msedge",
       "request": "attach",
-      "useWebView": true,
       "port": 9229,
       "timeout": 600000,
       "webRoot": "${workspaceRoot}",


### PR DESCRIPTION
From https://github.com/microsoft/vscode/issues/157587 I've learned that the useWebView is no longer needed for debugging with the Edge webview.

I validated that debugging an Excel task pane works even with this property removed.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
No.

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
Yes

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
No.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
I don't think so.


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

1. Opened the Office-Addin-TaskPane project in VS Code.
2. Ran the dev server.
3. Opened file excel.ts and set a breakpoint on line 25 which contains: range.load("address");
4. From Debug tab, selected "Excel Desktop (Edge Chromium)"
5. Click the play button to start debugging. 
6. When Excel opened, I clicked the ribbon button to open the task pane for the add-in, and clicked the Run button.
7. Hit the breakpoint.
