### PR TITLE
Update webpack config to use 'server' option

### DIFF
--- a/test/end-to-end/webpack.config.js
+++ b/test/end-to-end/webpack.config.js
@@ -8,7 +8,7 @@ const webpack = require("webpack");
 
 async function getHttpsOptions() {
   const httpsOptions = await devCerts.getHttpsServerOptions();
-  return { cacert: httpsOptions.ca, key: httpsOptions.key, cert: httpsOptions.cert };
+  return { ca: httpsOptions.ca, key: httpsOptions.key, cert: httpsOptions.cert };
 }
 
 module.exports = async (env, options) => {
@@ -87,7 +87,10 @@ module.exports = async (env, options) => {
       headers: {
         "Access-Control-Allow-Origin": "*",
       },
-      https: env.WEBPACK_BUILD || options.https !== undefined ? options.https : await getHttpsOptions(),
+      server: {
+        type: "https",
+        options: env.WEBPACK_BUILD || options.https !== undefined ? options.https : await getHttpsOptions(),
+      },
       port: process.env.npm_package_config_dev_server_port || 3000,
     },
   };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ const urlProd = "https://www.contoso.com/"; // CHANGE THIS TO YOUR PRODUCTION DE
 
 async function getHttpsOptions() {
   const httpsOptions = await devCerts.getHttpsServerOptions();
-  return { cacert: httpsOptions.ca, key: httpsOptions.key, cert: httpsOptions.cert };
+  return { ca: httpsOptions.ca, key: httpsOptions.key, cert: httpsOptions.cert };
 }
 
 module.exports = async (env, options) => {
@@ -93,7 +93,10 @@ module.exports = async (env, options) => {
       headers: {
         "Access-Control-Allow-Origin": "*",
       },
-      https: env.WEBPACK_BUILD || options.https !== undefined ? options.https : await getHttpsOptions(),
+      server: {
+        type: "https",
+        options: env.WEBPACK_BUILD || options.https !== undefined ? options.https : await getHttpsOptions(),
+      },
       port: process.env.npm_package_config_dev_server_port || 3000,
     },
   };


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:
webpack-dev-server has been reporting some config deprecations when being run.  This updates the config to use the new options for dev server that replace the deprecated ones.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
No.

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
No.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
No.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
Np/

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran automated tests