### PR TITLE
Update launch.json to include dependson npm install

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,6 +7,9 @@
       "label": "Build (Development)",
       "type": "npm",
       "script": "build:dev",
+      "dependsOn": [
+        "Install"
+      ],
       "group": {
         "kind": "build",
         "isDefault": true
@@ -21,6 +24,9 @@
       "label": "Build (Production)",
       "type": "npm",
       "script": "build",
+      "dependsOn": [
+        "Install"
+      ],
       "group": "build",
       "presentation": {
         "clear": true,
@@ -32,6 +38,9 @@
       "label": "Debug: Excel Desktop",
       "type": "npm",
       "script": "start:desktop -- --app excel",
+      "dependsOn": [
+        "Install"
+      ],
       "presentation": {
         "clear": true,
         "panel": "dedicated",
@@ -42,6 +51,9 @@
       "label": "Debug: Outlook Desktop",
       "type": "npm",
       "script": "start:desktop -- --app outlook",
+      "dependsOn": [
+        "Install"
+      ],
       "presentation": {
         "clear": true,
         "panel": "dedicated",
@@ -52,6 +64,9 @@
       "label": "Debug: PowerPoint Desktop",
       "type": "npm",
       "script": "start:desktop -- --app powerpoint",
+      "dependsOn": [
+        "Install"
+      ],
       "presentation": {
         "clear": true,
         "panel": "dedicated",
@@ -62,6 +77,9 @@
       "label": "Debug: Word Desktop",
       "type": "npm",
       "script": "start:desktop -- --app word",
+      "dependsOn": [
+        "Install"
+      ],
       "presentation": {
         "clear": true,
         "panel": "dedicated",
@@ -75,6 +93,9 @@
       "label": "Debug: Web",
       "type": "npm",
       "script": "start:web -- --document ${input:officeOnlineDocumentUrl}",
+      "dependsOn": [
+        "Install"
+      ],
       "presentation": {
         "clear": true,
         "panel": "shared",


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:
Updating VS Code launch.json file to include a dependsOn property for debugging.  This is to make sure the 'npm install' has been run and brings this in line with the Teams development process.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
No.

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
Yes.  'npm install' will now get run as part of debugging with VS Code which wasn't done before.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
No.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
Maybe.  Might want to double check docs relating to debugging through VS Code.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran VS Code debugging on the project so see the impact of running the install command.  Ran automated tests.