### PR TITLE
Remove browser launch and task json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -125,21 +125,6 @@
       "webRoot": "${workspaceRoot}",
       "preLaunchTask": "Debug: Word Desktop",
       "postDebugTask": "Stop Debug"
-    },
-    {
-      "name": "Office Online (Chrome)",
-      "type": "chrome",
-      "request": "launch",
-      "webRoot": "${workspaceFolder}",
-      "preLaunchTask": "Debug: Web"
-    },
-    {
-      "name": "Office Online (Edge Chromium)",
-      "type": "msedge",
-      "request": "launch",
-      "port": 9222,
-      "webRoot": "${workspaceFolder}",
-      "preLaunchTask": "Debug: Web"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -69,20 +69,6 @@
       "problemMatcher": []
     },
     {
-      // To debug your Add-in:
-      // 1. When prompted, enter the url (share link) to an Office Online document.
-      // 2. Sideload your Add-in. https://docs.microsoft.com/en-us/office/dev/add-ins/testing/sideload-office-add-ins-for-testing
-      "label": "Debug: Web",
-      "type": "npm",
-      "script": "start:web -- --document ${input:officeOnlineDocumentUrl}",
-      "presentation": {
-        "clear": true,
-        "panel": "shared",
-        "showReuseMessage": false
-      },
-      "problemMatcher": []
-    },
-    {
       "label": "Dev Server",
       "type": "npm",
       "script": "dev-server",
@@ -140,12 +126,5 @@
       },
       "problemMatcher": []
     },
-  ],
-  "inputs": [
-    {
-      "id": "officeOnlineDocumentUrl",
-      "type": "promptString",
-      "description": "Please enter the url for the Office Online document."
-    }
   ]
 }


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:
Current functionality of the sideloading cli doesn't work with vs code launch config options.  Sideloading needs to be updated in order to support it.  Removing for the time being.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
Nol

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
Yes.  Removing some options that don't work.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
Yes.  VS code support files have been updated.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
Possibly . . . if there is anything the specifically refers to debugging office online then it will need to be looked at.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Describe manual testing done. 
