### PR TITLE
[JSON] Use associate instead of global

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Office-Addin-TaskPane
 
-This repository contains the source code used by the [Yo Office generator](https://github.com/OfficeDev/generator-office/tree/json-yo-office) when you create a new Office Add-in that appears in the task pane. You can also use this repository as a sample to base your own project from if you choose not to use the generator. 
+This repository contains the source code used by the [Yo Office generator](https://github.com/OfficeDev/generator-office/tree/json-yo-office) when you create a new Office Add-in that appears in the task pane. You can also use this repository as a sample to base your own project from if you choose not to use the generator.
 
 ## TypeScript
 
@@ -8,20 +8,22 @@ This template is written using [TypeScript](http://www.typescriptlang.org/).
 
 ## Debugging
 
-This template supports debugging using any of the following techniques:
+This template supports debugging using any of the following techniques.
 
-- [Use a browser's developer tools](https://docs.microsoft.com/office/dev/add-ins/testing/debug-add-ins-in-office-online)
-- [Attach a debugger from the task pane](https://docs.microsoft.com/office/dev/add-ins/testing/attach-debugger-from-task-pane)
-- [Use F12 developer tools on Windows 10](https://docs.microsoft.com/office/dev/add-ins/testing/debug-add-ins-using-f12-developer-tools-on-windows-10)
+- [Use a browser's developer tools](https://learn.microsoft.com/office/dev/add-ins/testing/debug-add-ins-in-office-online)
+- [Attach a debugger from the task pane](https://learn.microsoft.com/office/dev/add-ins/testing/attach-debugger-from-task-pane)
+- [Use F12 developer tools on Windows 10](https://learn.microsoft.com/office/dev/add-ins/testing/debug-add-ins-using-f12-developer-tools-on-windows-10)
 
 ## Questions and comments
 
 We'd love to get your feedback about this sample. You can send your feedback to us in the *Issues* section of this repository.
 
-Questions about Office Add-ins development in general should be posted to [Microsoft Q&A](https://docs.microsoft.com/answers/questions/185087/questions-about-office-add-ins.html). If your question is about the Office JavaScript APIs, make sure it's tagged with [office-js-dev].
+Questions about Office Add-ins development in general should be posted to [Microsoft Q&A](https://learn.microsoft.com/answers/questions/185087/questions-about-office-add-ins.html). If your question is about the Office JavaScript APIs, make sure it's tagged with [office-js-dev].
 
 ## Join the Microsoft 365 Developer Program
+
 Get a free sandbox, tools, and other resources you need to build solutions for the Microsoft 365 platform.
+
 - [Free developer sandbox](https://developer.microsoft.com/microsoft-365/dev-program#Subscription) Get a free, renewable 90-day Microsoft 365 E5 developer subscription.
 - [Sample data packs](https://developer.microsoft.com/microsoft-365/dev-program#Sample) Automatically configure your sandbox by installing user data and content to help you build your solutions.
 - [Access to experts](https://developer.microsoft.com/microsoft-365/dev-program#Experts) Access community events to learn from Microsoft 365 experts.
@@ -29,8 +31,8 @@ Get a free sandbox, tools, and other resources you need to build solutions for t
 
 ## Additional resources
 
-* [Office Add-ins documentation](https://docs.microsoft.com/office/dev/add-ins/overview/office-add-ins)
-* More Office Add-ins samples at [OfficeDev on Github](https://github.com/officedev)
+- [Office Add-ins documentation](https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
+- More Office Add-ins samples at [OfficeDev on Github](https://github.com/officedev)
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -3,10 +3,10 @@
  * See LICENSE in the project root for license information.
  */
 
-/* global global, Office, self, window */
+/* global Office */
 
 Office.onReady(() => {
-  // If needed, Office.js is ready to be called
+  // If needed, Office.js is ready to be called.
 });
 
 /**
@@ -21,24 +21,12 @@ function action(event: Office.AddinCommands.Event) {
     persistent: true,
   };
 
-  // Show a notification message
+  // Show a notification message.
   Office.context.mailbox.item.notificationMessages.replaceAsync("ActionPerformanceNotification", message);
 
-  // Be sure to indicate when the add-in command function is complete
+  // Be sure to indicate when the add-in command function is complete.
   event.completed();
 }
 
-function getGlobal() {
-  return typeof self !== "undefined"
-    ? self
-    : typeof window !== "undefined"
-    ? window
-    : typeof global !== "undefined"
-    ? global
-    : undefined;
-}
-
-const g = getGlobal() as any;
-
-// The add-in command functions need to be available in global scope
-g.action = action;
+// Register the function with Office.
+Office.actions.associate("action", action);


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:

    Describe what the PR is about. 

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start') No
    If Yes, briefly describe what is impacted.


2. **Do these changes impact *VS Code debugging* options (launch.json)?** No
    If Yes, briefly describe what is impacted.


3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents) Yes
    If Yes, briefly describe what is impacted.
    Use Office.actions.associate instead of getGlobal


4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins) No
    If Yes, briefly describe what is impacted.


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Describe manual testing done. 
