### PR TITLE
make XML and JSON versions match

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -22,7 +22,7 @@ function action(event: Office.AddinCommands.Event) {
   };
 
   // Show a notification message.
-  Office.context.mailbox.item.notificationMessages.replaceAsync("action", message);
+  Office.context.mailbox.item.notificationMessages.replaceAsync("ActionPerformanceNotification", message);
 
   // Be sure to indicate when the add-in command function is complete.
   event.completed();

--- a/src/taskpane/outlook.ts
+++ b/src/taskpane/outlook.ts
@@ -17,4 +17,7 @@ export async function run() {
   /**
    * Insert your Outlook code here
    */
+
+  const item = Office.context.mailbox.item;
+  document.getElementById("item-subject").innerHTML = "<b>Subject:</b> <br/>" + item.subject;
 }

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -48,6 +48,7 @@
         <div role="button" id="run" class="ms-welcome__action ms-Button ms-Button--hero ms-font-xl">
             <span class="ms-Button-label">Run</span>
         </div>
+        <p><label id="item-subject"></label></p>
     </main>
 </body>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = async (env, options) => {
       clean: true,
     },
     resolve: {
-      extensions: [".ts", ".tsx", ".html", ".js"],
+      extensions: [".ts", ".html", ".js"],
     },
     module: {
       rules: [
@@ -43,11 +43,6 @@ module.exports = async (env, options) => {
           test: /\.tsx?$/,
           exclude: /node_modules/,
           use: "ts-loader",
-        },
-        {
-          test: /\.html$/,
-          exclude: /node_modules/,
-          use: "html-loader",
         },
         {
           test: /\.(png|jpg|jpeg|gif|ico)$/,


### PR DESCRIPTION
**Change Description**:

We're going to eliminate the "json-preview*" branches and make the difference between the XML and JSON manifest versions implemented by the generator and the convertToSingleHost.js file. To make this easier, we need to remove differences between the XML and JSON versions which have nothing to do with the difference in manifest formats. For example, the XML version had no code in the `run` method of the commands.ts file, but the JSON version does. So this PR makes the XML version match the JSON version. 

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
    If Yes, briefly describe what is impacted.
No

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
    If Yes, briefly describe what is impacted.
No

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
    If Yes, briefly describe what is impacted.
Yes. the commands.ts, taskpane.ts, and taskpane.html files are slightly changed.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    If Yes, briefly describe what is impacted.
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    The changes work locally. 
