### PR TITLE
remove obsolete line from convert script

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -148,7 +148,6 @@ async function deleteJSONManifestRelatedFiles() {
 }
 
 async function deleteXMLManifestRelatedFiles() {
-  await unlinkFileAsync("webpack.config.js");
   await unlinkFileAsync("manifest.xml");
 }
 


### PR DESCRIPTION
**Change Description**:

Somehow the last version of the convert script that I tested was not the version that got included in the previous PR. It had a left over line from when we had 2 webpack instead of editing one webpack.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
no

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
no

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
Yes. It prevents the webpack from being mistakenly left out of the output.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
no


**Validation/testing performed**:

Everything works.
