### PR TITLE
User/millerds/convert without module

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -3,7 +3,7 @@
 const fs = require("fs");
 const path = require("path");
 const util = require("util");
-const manifest = require("office-addin-manifest");
+const childProcess = require("child_process");
 
 const host = process.argv[2];
 const manifestType = process.argv[3];
@@ -263,6 +263,15 @@ if (projectName) {
   if (!appId) {
     appId = "random";
   }
-  manifest.OfficeAddinManifest.modifyManifestFile(manifestPath, appId, projectName);
+
+  // Modify the manifest to include the name and id of the project
+  const cmdLine = `npx office-addin-manifest modify ${manifestPath} -g ${appId} -d ${projectName}`;
+  childProcess.exec(cmdLine, (error, stdout) => {
+    if (error) {
+      Promise.reject(stdout);
+    } else {
+      Promise.resolve();
+    }
+  });
 }
  

--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -68,7 +68,7 @@ async function updatePackageJsonForSingleHost(host) {
   const packageJson = `./package.json`;
   const data = await readFileAsync(packageJson, "utf8");
   let content = JSON.parse(data);
-  
+
   // Update 'config' section in package.json to use selected host
   content.config["app_to_debug"] = host;
 
@@ -77,10 +77,7 @@ async function updatePackageJsonForSingleHost(host) {
 
   // Remove scripts that are unrelated to the selected host
   Object.keys(content.scripts).forEach(function (key) {
-    if (
-      key === "convert-to-single-host" ||
-      key === "start:desktop:outlook"
-    ) {
+    if (key === "convert-to-single-host" || key === "start:desktop:outlook") {
       delete content.scripts[key];
     }
   });
@@ -98,7 +95,7 @@ async function updatePackageJsonForSingleHost(host) {
       delete content.devDependencies[key];
     }
   });
-  
+
   // Write updated JSON to file
   await writeFileAsync(packageJson, JSON.stringify(content, null, 2));
 }
@@ -159,7 +156,7 @@ async function updatePackageJsonForXMLManifest() {
   // Remove scripts that are only used with JSON manifest
   delete content.scripts["signin"];
   delete content.scripts["signout"];
-  
+
   // Write updated JSON to file
   await writeFileAsync(packageJson, JSON.stringify(content, null, 2));
 }
@@ -176,11 +173,11 @@ async function updatePackageJsonForJSONManifest() {
     }
   });
 
-  // Change manifest file name extension  
+  // Change manifest file name extension
   content.scripts.start = "office-addin-debugging start manifest.json";
   content.scripts.stop = "office-addin-debugging stop manifest.json";
   content.scripts.validate = "office-addin-manifest validate manifest.json";
-  
+
   // Write updated JSON to file
   await writeFileAsync(packageJson, JSON.stringify(content, null, 2));
 }
@@ -192,30 +189,30 @@ async function updateTasksJsonFileForJSONManifest() {
 
   content.tasks.forEach(function (task) {
     if (task.label.startsWith("Build")) {
-      task.dependsOn = [ "Install" ];
-    };
+      task.dependsOn = ["Install"];
+    }
     if (task.label === "Debug: Outlook Desktop") {
       task.script = "start";
-      task.dependsOn = [ "Check OS", "Install" ];
+      task.dependsOn = ["Check OS", "Install"];
     }
   });
-  
-  const checkOSTask =  {
+
+  const checkOSTask = {
     label: "Check OS",
     type: "shell",
     windows: {
-      command: "echo 'Sideloading in Outlook on Windows is supported'"
+      command: "echo 'Sideloading in Outlook on Windows is supported'",
     },
     linux: {
-      command: "echo 'Sideloading on Linux is not supported' && exit 1"
+      command: "echo 'Sideloading on Linux is not supported' && exit 1",
     },
     osx: {
-      command: "echo 'Sideloading in Outlook on Mac is not supported' && exit 1"
+      command: "echo 'Sideloading in Outlook on Mac is not supported' && exit 1",
     },
     presentation: {
       clear: true,
-      panel: "dedicated"
-    }
+      panel: "dedicated",
+    },
   };
 
   content.tasks.push(checkOSTask);
@@ -247,7 +244,7 @@ modifyProjectForSingleHost(host).catch((err) => {
 
 let manifestPath = "manifest.xml";
 
-if ((host !== "outlook") || (manifestType !== "json")) {
+if (host !== "outlook" || manifestType !== "json") {
   // Remove things that are only relevant to JSON manifest
   deleteJSONManifestRelatedFiles();
   updatePackageJsonForXMLManifest();
@@ -257,7 +254,7 @@ if ((host !== "outlook") || (manifestType !== "json")) {
     console.error(`Error modifying for JSON manifest: ${err instanceof Error ? err.message : err}`);
     process.exitCode = 1;
   });
-};
+}
 
 if (projectName) {
   if (!appId) {
@@ -274,4 +271,3 @@ if (projectName) {
     }
   });
 }
- 


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:
Requiring 'office-addin-manifest' in the convertToSingleHost.js script requires a previous 'npm install' to have been performed, but in the process of creating a new project 'npm install' is the last thing to happen and so this doesn't work.  Using the npx cli command instead allows the call to happen on a temp install of that module and leave the full 'npm install' to happen later.  Other options considered were:
- Call 'npm install office-addin-manifest' before in the 'convert-to-single-host' command in package.json => still installs all dependencies and takes a bit longer
- Call 'npm install in 'generator-office' before calling the convert script => ends up installing extra dependencies for things that will get removed by the convert script (like test code dependencies)
- Return to calling office-addin-manifest.modify in generator-office => returns to a tight coupling between the plugin and template repo which is complicated by the fact that we have multiple manifests to choose from (and we've had to make plugin update based on file location changes).

The trade off of between this solution and that last option (return to coupling) is a bit of performance in the convert script (takes a handful of seconds to run the npx command)

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
No

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
No.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
No.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran convert script when I didn't have and node_modules installed using various cli parameters for the manifest type, host, name, and id