### PR TITLE
Preinstall convert requred package and keep sign in/out scripts

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -261,9 +261,10 @@ if (projectName) {
   const cmdLine = `npx office-addin-manifest modify ${manifestPath} -g ${appId} -d ${projectName}`;
   childProcess.exec(cmdLine, (error, stdout) => {
     if (error) {
-      Promise.reject(stdout);
+      console.error(`Error updating the manifest: ${error}`);
+      process.exitCode = 1;
     } else {
-      Promise.resolve();
+      console.log(stdout);
     }
   });
 }

--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -153,10 +153,6 @@ async function updatePackageJsonForXMLManifest() {
   const data = await readFileAsync(packageJson, "utf8");
   let content = JSON.parse(data);
 
-  // Remove scripts that are only used with JSON manifest
-  delete content.scripts["signin"];
-  delete content.scripts["signout"];
-
   // Write updated JSON to file
   await writeFileAsync(packageJson, JSON.stringify(content, null, 2));
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "webpack --mode production",
     "build:dev": "webpack --mode development",
-    "convert-to-single-host": "npm install office-addin-manifest && node convertToSingleHost.js",
+    "convert-to-single-host": "node convertToSingleHost.js",
     "dev-server": "webpack serve --mode development",
     "lint": "office-addin-lint check",
     "lint:fix": "office-addin-lint fix",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "webpack --mode production",
     "build:dev": "webpack --mode development",
-    "convert-to-single-host": "node convertToSingleHost.js",
+    "convert-to-single-host": "npm install office-addin-manifest && node convertToSingleHost.js",
     "dev-server": "webpack serve --mode development",
     "lint": "office-addin-lint check",
     "lint:fix": "office-addin-lint fix",


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:
 keeping the sign in/out script because everything has to go through the new service now.  Adding logging to the npx command to help with error that might arise for customers.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
Yes.  We keep a couple in more scenarios.

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
No.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
No.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
I don't think so.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran tests locally and ran convert script locally.
