### PR TITLE
Update conversion script to support multiword add-in names

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -279,7 +279,7 @@ if (projectName) {
   }
 
   // Modify the manifest to include the name and id of the project
-  const cmdLine = `npx office-addin-manifest modify ${manifestPath} -g ${appId} -d ${projectName}`;
+  const cmdLine = `npx office-addin-manifest modify ${manifestPath} -g ${appId} -d "${projectName}"`;
   childProcess.exec(cmdLine, (error, stdout) => {
     if (error) {
       console.error(`Error updating the manifest: ${error}`);


### PR DESCRIPTION
**Change Description**:

Update conversion script to support multiword add-in names. Just adds quotation marks.


1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
    If Yes, briefly describe what is impacted.
no

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
    If Yes, briefly describe what is impacted.
no

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
    If Yes, briefly describe what is impacted.
Yes. The manifest will be accurate if the user enters a multiword name for the add-in.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct 

**Validation/testing performed**:

Ran the conversion script locally with multiword names and it works. 
