### PR TITLE
Fix bug that this add-in can't launch in wac

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -105,6 +105,9 @@
       ],
       "ribbons": [
         {
+          "requirements": {
+            "capabilities": [{ "name": "Mailbox", "minVersion": "1.3" }]
+          },
           "contexts": [
             "mailRead"
           ],


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:

    The previous manifest causes add-in not able to launch in Office Online WXP because of missing of the requirement set of control that is only supposed to be used in Outlook.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
    If Yes, briefly describe what is impacted.
No

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
    If Yes, briefly describe what is impacted.
No

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
    If Yes, briefly describe what is impacted.
No

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
 No


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Describe manual testing done. 
