### PR TITLE
Guard convertToSingleHost against deeply nested JSON config files

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -38,6 +38,20 @@ const readFileAsync = util.promisify(fs.readFile);
 const unlinkFileAsync = util.promisify(fs.unlink);
 const writeFileAsync = util.promisify(fs.writeFile);
 
+// JSON.stringify is recursive and throws a "Maximum call stack size exceeded" RangeError on
+// extremely deeply nested input. Catch that here and rethrow a clear, actionable message that
+// names the file being written.
+function stringifyJson(content, fileName) {
+  try {
+    return JSON.stringify(content, null, 2);
+  } catch (err) {
+    if (err instanceof RangeError) {
+      throw new Error(`Unable to update "${fileName}": its JSON content is too deeply nested.`);
+    }
+    throw err;
+  }
+}
+
 async function modifyProjectForSingleHost(host) {
   if (!targetHosts || targetHosts.length === 0) {
     throw new Error("No target hosts were provided.");
@@ -161,7 +175,7 @@ async function updatePackageJsonForSingleHost(host, manifestType) {
   }
 
   // Write updated JSON to file
-  await writeFileAsync(packageJson, JSON.stringify(content, null, 2));
+  await writeFileAsync(packageJson, stringifyJson(content, packageJson));
 }
 
 async function updateLaunchJsonFile() {
@@ -174,7 +188,7 @@ async function updateLaunchJsonFile() {
       return config.name.toLowerCase().startsWith(host);
     });
   });
-  await writeFileAsync(launchJson, JSON.stringify(content, null, 2));
+  await writeFileAsync(launchJson, stringifyJson(content, launchJson));
 }
 
 function deleteFolder(folder) {


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:

`convertToSingleHost.js` reads config files (launch.json / package.json / tasks.json), modifies them, and writes them back with `JSON.stringify(content, null, 2)`. Node's `JSON.stringify` is recursive, so a config file containing extremely deeply nested JSON causes an opaque `RangeError: Maximum call stack size exceeded` (the earlier `JSON.parse` succeeds because it is iterative).

This PR wraps the write-back serialization in a small `stringifyJson(content, fileName)` helper that catches that `RangeError` and rethrows a clear, actionable message naming the file being written, instead of an opaque stack overflow. Normal template content is unaffected.

This mirrors the fix already merged in OfficeDev/Excel-Custom-Functions#504, applied here because `convertToSingleHost.js` is duplicated across the template repos.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
=> No

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
=> No

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
=> No

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
=> No

**Validation/testing performed**:

- Ran the modified script's serialization against a config object with a JSON nesting depth of 20000. Before: crashed with "RangeError: Maximum call stack size exceeded". After: fails with a clear message: `Unable to update ".vscode/launch.json": its JSON content is too deeply nested.`
- Verified normal config content serializes unchanged.
- `node --check convertToSingleHost.js` passes.