### PR TITLE
Fix unit tests on Node 24 and prevent E2E runs from hanging in CI

### DIFF
--- a/.azure-devops/full-pipeline.yml
+++ b/.azure-devops/full-pipeline.yml
@@ -19,6 +19,10 @@ extends:
       jobs:
       - job: Windows_Latest
         steps:
+        - task: NodeTool@0
+          displayName: 'Use Node 22.x'
+          inputs:
+            versionSpec: '22.x'
         - template: /.azure-devops/install.yml@self
         - template: /.azure-devops/lint.yml@self
         - template: /.azure-devops/build.yml@self

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,3 @@
+{
+  "node-option": ["no-experimental-strip-types"]
+}

--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -204,6 +204,9 @@ async function deleteSupportFiles() {
   await unlinkFileAsync("./convertToSingleHost.js");
   await unlinkFileAsync(".npmrc");
   await unlinkFileAsync("package-lock.json");
+  if (fs.existsSync(".mocharc.json")) {
+    await unlinkFileAsync(".mocharc.json");
+  }
 }
 
 async function deleteJSONManifestRelatedFiles() {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev_server_port": 3000
   },
   "engines": {
-    "node": ">=20 <25",
+    "node": ">=22 <25",
     "npm": ">=9 <12"
   },
   "scripts": {

--- a/test/end-to-end/ui-test.ts
+++ b/test/end-to-end/ui-test.ts
@@ -12,6 +12,9 @@ import * as testHelpers from "./src/test-helpers";
 const hosts = ["Excel", "PowerPoint", "Word"];
 const manifestPath = path.resolve(`${process.cwd()}/test/end-to-end/test-manifest.xml`);
 const testServerPort: number = 4201;
+// Finite timeout so a stuck sideload fails within minutes instead of hanging
+// until the CI job's timeout cancels the whole run.
+const testTimeout: number = 5 * 60 * 1000;
 
 hosts.forEach(function (host) {
   const testServer = new officeAddinTestServer.TestServer(testServerPort);
@@ -19,7 +22,7 @@ hosts.forEach(function (host) {
 
   describe(`Test ${host} Task Pane Project`, function () {
     before(`Setup test environment and sideload ${host}`, async function () {
-      this.timeout(0);
+      this.timeout(testTimeout);
       // Start test server and ping to ensure it's started
       const testServerStarted = await testServer.startTestServer(true /* mochaTest */);
       const serverResponse = await officeAddinTestHelpers.pingTestServer(testServerPort);
@@ -39,7 +42,7 @@ hosts.forEach(function (host) {
     }),
       describe(`Get test results for ${host} taskpane project`, function () {
         it("Validate expected result count", async function () {
-          this.timeout(0);
+          this.timeout(testTimeout);
           testValues = await testServer.getTestResults();
           assert.strictEqual(testValues.length > 0, true);
         });
@@ -54,7 +57,7 @@ hosts.forEach(function (host) {
         });
       });
     after(`Teardown test environment and shutdown ${host}`, async function () {
-      this.timeout(0);
+      this.timeout(testTimeout);
       // Stop the test server
       const stopTestServer = await testServer.stopTestServer();
       assert.strictEqual(stopTestServer, true);


### PR DESCRIPTION
## Problem

Recent PRs fail on the **`Office-Addin-TaskPane (stage Windows_Latest)`** check. Two distinct issues:

1. **Unit tests break on Node 24.** Node 24 enables native TypeScript type-stripping by default. It intercepts the `.ts` test files before `ts-node/register` and loads them as ES modules, so `require(...)` in the tests throws `ReferenceError: require is not defined` (Excel/PowerPoint/Word "Run").
2. **E2E stage hangs until the job timeout.** `test/end-to-end/ui-test.ts` sideloads desktop Excel/PowerPoint/Word and every hook/test used `this.timeout(0)`. When a sideload stalls, the run blocks until the CI job's ~60-min cap and is **cancelled** — which matches the identical ~1h cancellations seen across unrelated dependency-bump PRs.

## Changes

- **`.mocharc.json`** — adds `--no-experimental-strip-types` so ts-node handles `.ts` as CommonJS on Node 24. Applies to both unit and E2E mocha runs.
- **`test/end-to-end/ui-test.ts`** — replaces `this.timeout(0)` with a finite `testTimeout` (5 min) on the sideload/result hooks so a hang fails fast instead of burning the whole job.
- **`.azure-devops/full-pipeline.yml`** — pins the pipeline to Node 22.x (`NodeTool@0`) to stop pool-image drift and guarantee a Node that supports the mocha flag.
- **`package.json`** — bumps `engines.node` floor to `>=22` (Node 20 is EOL; the mocha flag needs ≥22.6).
- **`convertToSingleHost.js`** — removes the now-orphaned `.mocharc.json` during single-host conversion.

## Validation

Ran locally on **Node v24.12.0**:
- `npm run lint` ✅
- `npm run build` ✅
- `npm run test:unit` ✅ (3 passing — previously 3 failing with the require error)

⚠️ **`npm run test:e2e` was not run locally** — it sideloads desktop Office and requires a machine with Office installed. The `testTimeout` value (5 min) may need tuning on a real CI agent; reviewers with an Office-equipped environment should validate the E2E behavior.

Opened as a **draft** pending E2E validation.
