### PR TITLE
Fix convert script npm registry usages

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -305,4 +305,7 @@ async function main() {
   }
 }
 
-main();
+main().catch((err) => {
+   console.error(`Unhandled error: ${err instanceof Error ? err.message : err}`);
+   process.exitCode = 1;
+ });

--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -252,43 +252,55 @@ async function modifyProjectForJSONManifest() {
   await deleteXMLManifestRelatedFiles();
 }
 
-/**
- * Modify the project so that it only supports a single host.
- * @param host The host to support.
- */
-modifyProjectForSingleHost(host).catch((err) => {
-  console.error(`Error modifying for single host: ${err instanceof Error ? err.message : err}`);
-  process.exitCode = 1;
-});
+async function main() {
 
-let manifestPath = "manifest.xml";
-
-if (manifestType !== "json") {
-  // Remove things that are only relevant to JSON manifest
-  deleteJSONManifestRelatedFiles();
-} else {
-  manifestPath = "manifest.json";
-  modifyProjectForJSONManifest().catch((err) => {
-    console.error(`Error modifying for JSON manifest: ${err instanceof Error ? err.message : err}`);
+  try {
+    /**
+     * Modify the project so that it only supports a single host.
+     * @param host The host to support.
+     */
+    await modifyProjectForSingleHost(host);
+  } catch (err) {
+    console.error(`Error modifying for single host: ${err instanceof Error ? err.message : err}`);
     process.exitCode = 1;
-  });
-}
-
-if (projectName) {
-  if (!appId) {
-    appId = "random";
+    return;
   }
 
-  // Modify the manifest to include the name and id of the project
-  const cmdLine = `npx office-addin-manifest modify ${manifestPath} -g ${appId} -d "${projectName}"`;
-  childProcess.exec(cmdLine, (error, stdout) => {
-    if (error) {
-      console.error(`Error updating the manifest: ${error}`);
+  let manifestPath = "manifest.xml";
+
+  if (manifestType !== "json") {
+    // Remove things that are only relevant to JSON manifest
+    await deleteJSONManifestRelatedFiles();
+  } else {
+    manifestPath = "manifest.json";
+    try {
+      await modifyProjectForJSONManifest();
+    } catch (err) {
+      console.error(`Error modifying for JSON manifest: ${err instanceof Error ? err.message : err}`);
       process.exitCode = 1;
-      Promise.reject(stdout);
-    } else {
-      console.log(stdout);
-      Promise.resolve();
+      return;
     }
-  });
+  }
+
+  if (projectName) {
+    if (!appId) {
+      appId = "random";
+    }
+
+    // Modify the manifest to include the name and id of the project
+    const cmdLine = `npx office-addin-manifest modify ${manifestPath} -g ${appId} -d "${projectName}"`;
+    await new Promise((resolve) => {
+      childProcess.exec(cmdLine, (error, stdout) => {
+        if (error) {
+          console.error(`Error updating the manifest: ${error}`);
+          process.exitCode = 1;
+        } else {
+          console.log(stdout);
+        }
+        resolve();
+      });
+    });
+  }
 }
+
+main();

--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -289,8 +289,10 @@ async function main() {
 
     // Modify the manifest to include the name and id of the project
     const cmdLine = `npx office-addin-manifest modify ${manifestPath} -g ${appId} -d "${projectName}"`;
+    const execEnv = { ...process.env };
+    delete execEnv.npm_config_registry;
     await new Promise((resolve) => {
-      childProcess.exec(cmdLine, (error, stdout) => {
+      childProcess.exec(cmdLine, { env: execEnv }, (error, stdout) => {
         if (error) {
           console.error(`Error updating the manifest: ${error}`);
           process.exitCode = 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -510,23 +510,23 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.17.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-browser/-/msal-browser-5.17.1.tgz",
-      "integrity": "sha1-EozjSq27IGyUDpnKXgzxldEsbfw=",
+      "version": "5.18.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-browser/-/msal-browser-5.18.0.tgz",
+      "integrity": "sha1-RGubQmeKIgQZ70MFT9/BOFWhLC4=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@azure/msal-common": "16.11.2"
+        "@azure/msal-common": "16.12.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.11.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-common/-/msal-common-16.11.2.tgz",
-      "integrity": "sha1-bLo7L5utC9sH7o37+nLv9Lo2nDA=",
+      "version": "16.12.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-common/-/msal-common-16.12.0.tgz",
+      "integrity": "sha1-XL1Y25GUj5I4LoxijzSlf0adOnQ=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -535,14 +535,14 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.4.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-node/-/msal-node-5.4.2.tgz",
-      "integrity": "sha1-EeB7IuSZAznQzjMVTg7+pLLFUPo=",
+      "version": "5.5.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-node/-/msal-node-5.5.0.tgz",
+      "integrity": "sha1-1JivIxqllWZkKJve00fAVrX357M=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@azure/msal-common": "16.11.2",
+        "@azure/msal-common": "16.12.0",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -614,16 +614,16 @@
       }
     },
     "node_modules/@azure/storage-common": {
-      "version": "12.4.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/storage-common/-/storage-common-12.4.1.tgz",
-      "integrity": "sha1-eMI6si3QTOJ7E9/omRtFtv3ts0U=",
+      "version": "12.5.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/storage-common/-/storage-common-12.5.0.tgz",
+      "integrity": "sha1-nbHWmPJu9LVqVKYABGp2XqG7oxY=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.9.0",
-        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-http-compat": "^2.4.0",
         "@azure/core-rest-pipeline": "^1.24.0",
         "@azure/core-tracing": "^1.2.0",
         "@azure/core-util": "^1.11.0",
@@ -632,7 +632,7 @@
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.12",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@hono/node-server/-/node-server-2.0.12.tgz",
-      "integrity": "sha1-I4dshkDse5zHfdRXdYRksSBqEc0=",
+      "version": "2.1.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha1-wYI+G5rda90UgH+7/sObi4BhSyU=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4629,9 +4629,9 @@
       "dev": true
     },
     "node_modules/@microsoft/app-manifest": {
-      "version": "1.0.7",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/app-manifest/-/app-manifest-1.0.7.tgz",
-      "integrity": "sha1-0+sp26sVBEHWFTXcL8xieyXnsas=",
+      "version": "1.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/app-manifest/-/app-manifest-1.1.1.tgz",
+      "integrity": "sha1-w2NwblkrkH7nynrOKHIv/zftuBU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4795,17 +4795,17 @@
       }
     },
     "node_modules/@microsoft/m365-spec-parser": {
-      "version": "0.2.14",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/m365-spec-parser/-/m365-spec-parser-0.2.14.tgz",
-      "integrity": "sha1-WA4PLBcQaQefiltl8RJOznDIYq8=",
+      "version": "0.3.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/m365-spec-parser/-/m365-spec-parser-0.3.1.tgz",
+      "integrity": "sha1-0P343A9nGfn1q19CwwxcRw1iyIw=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.1",
-        "@microsoft/app-manifest": "1.0.7",
+        "@microsoft/app-manifest": "1.1.1",
         "fs-extra": "^11.2.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.0",
         "openapi-types": "^7.2.3",
         "swagger2openapi": "^7.0.8"
       },
@@ -4830,9 +4830,9 @@
       }
     },
     "node_modules/@microsoft/m365agentstoolkit-cli": {
-      "version": "1.1.12",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/m365agentstoolkit-cli/-/m365agentstoolkit-cli-1.1.12.tgz",
-      "integrity": "sha1-xhlCQrUHxwUlKws6KNQo+G2BcuQ=",
+      "version": "1.1.15",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/m365agentstoolkit-cli/-/m365agentstoolkit-cli-1.1.15.tgz",
+      "integrity": "sha1-UChX+eFfkVOLomi7ctU8Dui9PQk=",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4841,13 +4841,13 @@
         "@azure/arm-subscriptions": "^5.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/identity": "^4.13.1",
-        "@azure/msal-node": "^5.2.2",
+        "@azure/msal-node": "^5.4.0",
         "@azure/msal-node-extensions": "^1.5.25",
         "@inquirer/core": "^5.1.2",
         "@inquirer/prompts": "^7.10.1",
         "@inquirer/type": "^1.1.5",
-        "@microsoft/teamsfx-api": "0.23.15",
-        "@microsoft/teamsfx-core": "3.0.14",
+        "@microsoft/teamsfx-api": "0.24.1",
+        "@microsoft/teamsfx-core": "3.1.2",
         "ansi-escapes": "^4.3.2",
         "applicationinsights": "^1.8.10",
         "async-mutex": "^0.3.1",
@@ -4862,6 +4862,7 @@
         "node-machine-id": "^1.1.12",
         "open": "^8.2.1",
         "semver": "^7.5.4",
+        "tas-client": "^0.1.73",
         "tree-kill": "^1.2.2",
         "underscore": "^1.13.8"
       },
@@ -4951,15 +4952,15 @@
       "peer": true
     },
     "node_modules/@microsoft/teamsfx-api": {
-      "version": "0.23.15",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/teamsfx-api/-/teamsfx-api-0.23.15.tgz",
-      "integrity": "sha1-u5WtgDi8RGkW0IHCmkLR/k3ZoHM=",
+      "version": "0.24.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/teamsfx-api/-/teamsfx-api-0.24.1.tgz",
+      "integrity": "sha1-PeQtzsax8sgK9E4RsaaZH4XDOLY=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@azure/core-auth": "^1.4.0",
-        "@microsoft/app-manifest": "1.0.7",
+        "@microsoft/app-manifest": "1.1.1",
         "chai": "^4.3.4",
         "jsonschema": "^1.4.0",
         "neverthrow": "^3.2.0",
@@ -4967,9 +4968,9 @@
       }
     },
     "node_modules/@microsoft/teamsfx-core": {
-      "version": "3.0.14",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/teamsfx-core/-/teamsfx-core-3.0.14.tgz",
-      "integrity": "sha1-9ai2++DkttDrWfeTBY1/OwuTjOQ=",
+      "version": "3.1.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/teamsfx-core/-/teamsfx-core-3.1.2.tgz",
+      "integrity": "sha1-ClJwPJDf8K5+i6PyBlYM9XdbrKQ=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4982,16 +4983,15 @@
         "@azure/core-auth": "^1.4.0",
         "@azure/core-rest-pipeline": "^1.22.1",
         "@azure/identity": "^4.1.0",
-        "@azure/msal-node": "^2.6.6",
         "@azure/storage-blob": "^12.25.0",
         "@feathersjs/hooks": "^0.6.5",
         "@microsoft/dev-tunnels-contracts": "1.1.9",
         "@microsoft/dev-tunnels-management": "1.1.9",
         "@microsoft/kiota": "1.31.1",
-        "@microsoft/m365-spec-parser": "^0.2.14",
-        "@microsoft/teamsfx-api": "0.23.15",
+        "@microsoft/m365-spec-parser": "^0.3.1",
+        "@microsoft/teamsfx-api": "0.24.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "ajv": "^8.18.0",
         "axios": "^1.8.3",
         "axios-retry": "^3.3.1",
@@ -5004,10 +5004,11 @@
         "fs-extra": "^9.1.0",
         "glob": "^13.0.0",
         "handlebars": "^4.7.7",
+        "https-proxy-agent": "^7.0.6",
         "iconv-lite": "^0.6.3",
         "ignore": "^5.1.8",
         "js-base64": "^3.6.0",
-        "js-yaml": "^4.0.0",
+        "js-yaml": "^4.3.0",
         "jsonschema": "^1.4.0",
         "klaw": "^3.0.0",
         "linkedom": "^0.18.9",
@@ -5028,38 +5029,23 @@
         "strip-bom": "^4.0.0",
         "swagger2openapi": "^7.0.8",
         "tar": "^7.4.3",
+        "tmp": "^0.2.5",
         "typedi": "^0.10.0",
-        "uuid": "^8.3.2",
+        "uuid": "^11.1.1",
         "validator": "^13.7.0",
         "xml2js": "^0.5.0",
-        "yaml": "^2.2.2"
+        "yaml": "^2.4.2"
       }
     },
-    "node_modules/@microsoft/teamsfx-core/node_modules/@azure/msal-common": {
-      "version": "14.16.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-common/-/msal-common-14.16.1.tgz",
-      "integrity": "sha1-0j7M5AgjpNA610Fg3IGdYuDAp4c=",
+    "node_modules/@microsoft/teamsfx-core/node_modules/adm-zip": {
+      "version": "0.6.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@microsoft/teamsfx-core/node_modules/@azure/msal-node": {
-      "version": "2.16.3",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-node/-/msal-node-2.16.3.tgz",
-      "integrity": "sha1-i4BRUq14CwSNbCszsdTibXtGM2g=",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@azure/msal-common": "14.16.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=16"
+        "node": ">=14.0"
       }
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/ajv": {
@@ -5106,9 +5092,9 @@
       }
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
+      "version": "5.0.9",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5226,14 +5212,14 @@
       }
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha1-vUhoegvjjtKWE5kQVgD4MglYYdE=",
+      "version": "10.2.6",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha1-/ZVrvgt3JB6fFaxdzLHGOAYJaO8=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -5285,6 +5271,17 @@
         "office-addin-manifest": "cli.js"
       }
     },
+    "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-manifest/node_modules/adm-zip": {
+      "version": "0.5.12",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/adm-zip/-/adm-zip-0.5.12.tgz",
+      "integrity": "sha1-h3hjKOkdVLNzWNilD5VMTNc7pgs=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-manifest/node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -5323,6 +5320,17 @@
         }
       }
     },
+    "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-manifest/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-usage-data": {
       "version": "1.6.14",
       "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/office-addin-usage-data/-/office-addin-usage-data-1.6.14.tgz",
@@ -5338,6 +5346,17 @@
       },
       "bin": {
         "office-addin-usage-data": "cli.js"
+      }
+    },
+    "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-usage-data/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/path-scurry": {
@@ -6601,9 +6620,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
+      "version": "5.0.9",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6698,9 +6717,9 @@
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.7",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.7.tgz",
-      "integrity": "sha1-mrJ1NYmDu9MLyJUM9NxX5kcGcPM=",
+      "version": "0.3.8",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
+      "integrity": "sha1-tN7lpeeXGu3HCVO7fS2/V4P0LTg=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -7447,15 +7466,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha1-1j+YY7zYk4gVyG+eKr04AYnZbf4=",
+      "version": "1.19.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha1-3fhk1MgjPA5oc3RqtZNhU30FrTk=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -7714,9 +7733,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.18",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9735,9 +9754,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
+      "version": "2.1.4",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10046,9 +10065,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha1-ThmOuRzTM9Co3cwDZQKzYYol9Ek=",
+      "version": "3.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha1-uWy7fazk83dPWKnjsa6aSlJIcuI=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -10115,9 +10134,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
-      "integrity": "sha1-LmSrEDYdo1iBUZ6pK0JqQ/iqjHk=",
+      "version": "8.6.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha1-Gmx/tsX1qDiDwU8dGY/N/2AIfF0=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -10211,9 +10230,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha1-Oz2vnOaPQflW3wtQUTLAz86ex68=",
+      "version": "3.1.5",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=",
       "dev": true,
       "funding": [
         {
@@ -10482,8 +10501,8 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
       "dev": true,
       "funding": [
         {
@@ -10795,9 +10814,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
+      "version": "2.1.4",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10994,9 +11013,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha1-LMqvPM2C2zcvFpxbOcBlwx/zYpQ=",
+      "version": "4.13.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha1-1KYGt5KVTQemIV0SwBt89Z2gPLw=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -11586,9 +11605,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha1-gF/BeLIMUYvUyFSLJP4wiS1/MgY=",
+      "version": "10.5.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha1-/NbX3+nmhBa3y3Gv6byWCz44wTs=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -12243,9 +12262,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.4",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/jose/-/jose-6.2.4.tgz",
-      "integrity": "sha1-ad5zRnYc0ElCxlnlJNmI/rFqSm4=",
+      "version": "6.2.8",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha1-OcFFn+XqyE6zmxYjuAd9z5ymxQY=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -12254,9 +12273,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "3.9.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/js-base64/-/js-base64-3.9.1.tgz",
-      "integrity": "sha1-AjNcFsajEckTXfpxtLO38a8z3Ug=",
+      "version": "3.9.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/js-base64/-/js-base64-3.9.2.tgz",
+      "integrity": "sha1-5AFRt4920ylDQO27ebIxuoIZO6E=",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true
@@ -12268,9 +12287,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
       "dev": true,
       "funding": [
         {
@@ -13282,9 +13301,9 @@
       "peer": true
     },
     "node_modules/mocha": {
-      "version": "11.7.6",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/mocha/-/mocha-11.7.6.tgz",
-      "integrity": "sha1-674imJ0Ey7lCSjYwcyBHZiTEGjM=",
+      "version": "11.8.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/mocha/-/mocha-11.8.0.tgz",
+      "integrity": "sha1-kWPMWWAOwmRw9rBA4wqlGsyXPtI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13319,9 +13338,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
+      "version": "2.1.4",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16687,9 +16706,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.21",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/tar/-/tar-7.5.21.tgz",
-      "integrity": "sha1-s0Ba8utJNSPOQ3n1Menr2gYBvFk=",
+      "version": "7.5.22",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha1-ppb5mBNucUh9w/hpqFu6LGeXG6k=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "peer": true,
@@ -16742,6 +16761,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tas-client": {
+      "version": "0.1.73",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/tas-client/-/tas-client-0.1.73.tgz",
+      "integrity": "sha1-Laz2hUejeYnvFVTGUQ3BCKHqenE=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "axios": "^1.6.1"
       }
     },
     "node_modules/terser": {
@@ -16898,6 +16928,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha1-JvTbEdFgHOgBLcuKeY7OHAapkFk=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
@@ -17431,14 +17472,18 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "version": "11.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha1-9tgdLhxl0Adi5eKbFsXS2ZXiCK0=",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "peer": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {


### PR DESCRIPTION
**Change Description**:
The convert script continued to use the private registry from .npmrc even though the file was deleted.  Needed to update the script to wait for the file deletion and then provide an execution environment that clears the setting.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
No (not the syntax).

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
No.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
No.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran the convert script locally in the project with various user registry settings different from the .npmrc file.