### PR TITLE
Update convert script to restore OneNote Project support

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -72,9 +72,6 @@ async function modifyProjectForSingleHost(host) {
   if (manifestType === "xml" && targetHosts.length > 1) {
     throw new Error(`Multiple hosts are not supported for ${manifestType} manifest.`);
   }
-  if (!commandsSupportedHosts.includes(host)) {
-    throw new Error(`'${host}' does not support commands.`);
-  }
 
   await convertProjectToSingleHost(host, manifestType);
 
@@ -120,8 +117,14 @@ async function convertProjectToSingleHost(host, manifestType) {
     }
   }
   
+  // Write final code files
   await writeFileAsync(taskpaneFilePath, taskpaneContent);
-  await writeFileAsync(commandsFilePath, commandsContent);
+  if (commandsSupportedHosts.includes(host)) {
+    await writeFileAsync(commandsFilePath, commandsContent);
+  } else {
+    deleteFolder(path.resolve(`./src/commands`));
+  }
+
   // Delete test folder
   deleteFolder(path.resolve(`./test`));
 


### PR DESCRIPTION
**Change Description**:

Restores ability to create projects for hosts that don't support Add-in Commands.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
No


2. **Do these changes impact *VS Code debugging* options (launch.json)?**
No


3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
Yes. Add-ins for Project and OneNote are now emitted.


4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No


If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

Tested the changed script locally. 
