### PR TITLE
Fix convertToSingleHost to use execFile

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -288,11 +288,12 @@ async function main() {
     }
 
     // Modify the manifest to include the name and id of the project
-    const cmdLine = `npx office-addin-manifest modify ${manifestPath} -g ${appId} -d "${projectName}"`;
     const execEnv = { ...process.env };
     delete execEnv.npm_config_registry;
+    const manifestCli = require.resolve("office-addin-manifest/cli.js");
+    const args = [manifestCli, "modify", manifestPath, "-g", appId, "-d", projectName];
     await new Promise((resolve) => {
-      childProcess.exec(cmdLine, { env: execEnv }, (error, stdout) => {
+      childProcess.execFile(process.execPath, args, { env: execEnv, shell: false }, (error, stdout) => {
         if (error) {
           console.error(`Error updating the manifest: ${error}`);
           process.exitCode = 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2457,38 +2457,41 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha1-qCcsoDsqz0kmcCIrIyC2xCG/3mA=",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.8",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha1-j4AMzME/T4zTEW4tnAqUk52j4+0=",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
       }
     },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha1-8qCfYgEjkLK/8/xvskjd7IwJoJA=",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -6923,9 +6926,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha1-ANHdlAshjf8uSTCdQQ2LshIVkiU=",
+      "version": "0.8.15",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha1-cev4Bynk6VIh1Rmsmx4erqd4SQc=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -7592,13 +7595,16 @@
       "peer": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.11.20",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/batch": {
@@ -7762,9 +7768,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.8",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -7782,11 +7788,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -7958,9 +7964,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001810",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -9120,9 +9126,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.418",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.418.tgz",
+      "integrity": "sha1-QMy/bVckR2YwQWEeBZJLU7yaAzE=",
       "dev": true,
       "license": "ISC"
     },
@@ -10088,8 +10094,8 @@
     },
     "node_modules/express": {
       "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
-      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/express/-/express-4.22.2.tgz",
+      "integrity": "sha1-wXrgmB5e/CSyInLw4EHEZiUDtwA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10230,9 +10236,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=",
+      "version": "3.1.6",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha1-v90wjvdj+DX+0Fnzxskl9wjjPjo=",
       "dev": true,
       "funding": [
         {
@@ -13617,11 +13623,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.54",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -15038,13 +15047,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -16122,14 +16132,15 @@
       "peer": true
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -16141,13 +16152,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17391,9 +17403,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
Hardens the `convertToSingleHost.js` conversion script against command injection and updates dependencies to resolve `npm audit` vulnerabilities.

## Changes
- **convertToSingleHost.js**: Replace `childProcess.exec` (shell string) with `childProcess.execFile(process.execPath, ...)` when invoking `office-addin-manifest modify`. The manifest CLI is now resolved via `require.resolve("office-addin-manifest/cli.js")` and arguments are passed as an array with `shell: false`, so the project name and app ID are no longer interpolated into a shell command line.